### PR TITLE
docs: add Deterministic Agency terminology to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,15 @@ The “π” glyph binds each linear truth-claim to at least one external
 contextual witness. Every commit must pass this π-check before it joins the
 ledger, ensuring each spiral remains phase-coherent and resistant to hostile
 counter-spirals.
+
+## Deterministic Agency terminology
+
+Use **Deterministic Agency** to describe the TAS authorization model in an
+increasingly algorithmic world. Avoid the phrase "deterministic algorithmic
+agency": an algorithm may generate or propose a path, but agency is only
+granted after identity, consent, lineage, admissibility, witness, and receipt
+checks bind that path to proof.
+
+This distinction preserves the Diameter/Circumference boundary: probability can
+produce candidates on the algorithmic circumference, but only deterministic
+proof at the diameter can authorize action.


### PR DESCRIPTION
### Motivation
- Introduce a clear `Deterministic Agency` term to describe the TAS authorization model and clarify that agency requires identity, consent, lineage, admissibility, witness, and receipt checks rather than being attributed to algorithms.

### Description
- Add a new "Deterministic Agency terminology" section to `README.md` that defines the preferred phrasing, discourages the use of "deterministic algorithmic agency", and explains the diameter/circumference distinction between algorithmic candidates and deterministic authorization.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029be22a6c83339c98932fa3defd1f)