### PR TITLE
Bind admission decisions to content-addressed context

### DIFF
--- a/admission_gate.py
+++ b/admission_gate.py
@@ -1,104 +1,46 @@
-"""Authenticated, fail-closed admission decisions.
+"""Authenticated, context-bound, fail-closed admission decisions.
 
-This module deliberately separates parsing, authority resolution, signature
-verification, evidence recording, and later state transitions.  It is an
-adapter boundary: private keys are only available to ``ReceiptSigner`` and are
-never reconstructed from public authority material.
+The gate resolves semantic context before candidate interpretation, then binds
+that exact context to an immutable authority checkpoint. Private keys remain
+behind ``ReceiptSigner`` and are never reconstructed from public material.
 """
 
 from __future__ import annotations
 
 import base64
 import hashlib
-import json
-import math
 import re
 from dataclasses import dataclass
-from datetime import datetime, timezone
-from typing import Any, Mapping, Protocol, Sequence
+from typing import Any, Mapping, Protocol
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
-from cryptography.hazmat.primitives.serialization import (
-    Encoding,
-    PublicFormat,
-    load_der_public_key,
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from context_snapshot import (
+    CANONICALIZATION_VERSION,
+    CanonicalJSONError,
+    ContextResolver,
+    ContextSnapshot,
+    ContextValidationError,
+    DefinitionResolver,
+    canonical_hash,
+    canonical_json,
+    domain_hash,
+    parse_canonical_json,
+    resolve_verified_context,
 )
 
-
 AUTHORIZATION_DOMAIN = b"TAS-AUTHORITY-GATE-V1\x00"
+AUTHORITY_BINDING_DOMAIN = b"TAS-AUTHORITY-BINDING-V1\x00"
 RECEIPT_DOMAIN = b"TAS-ADMISSION-RECEIPT-V1\x00"
-CANONICALIZATION_VERSION = "TAS-CJSON-1"
-RULE_SET_VERSION = "TAS-PI-GATE-1"
+RULE_SET_VERSION = "TAS-PI-GATE-2"
 _HEX_64 = re.compile(r"^[0-9a-f]{64}$")
-_SECP256K1_ORDER = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
-
-
-class CanonicalJSONError(ValueError):
-    """Raised when input is not part of the constrained TAS-CJSON-1 subset."""
-
-
-def _reject_duplicates(pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
-    result: dict[str, Any] = {}
-    for key, value in pairs:
-        if key in result:
-            raise CanonicalJSONError(f"duplicate JSON key: {key!r}")
-        result[key] = value
-    return result
-
-
-def parse_canonical_json(raw: bytes, *, max_bytes: int = 65536, max_depth: int = 32,
-                         max_nodes: int = 4096) -> Any:
-    """Decode untrusted UTF-8 JSON after rejecting ambiguous/non-portable forms."""
-    if not isinstance(raw, bytes) or len(raw) > max_bytes:
-        raise CanonicalJSONError("JSON input exceeds byte limit")
-    try:
-        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_reject_duplicates,
-                           parse_constant=lambda value: (_ for _ in ()).throw(
-                               CanonicalJSONError(f"invalid JSON constant: {value}")))
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise CanonicalJSONError("invalid UTF-8 JSON") from error
-
-    nodes = 0
-    def validate(item: Any, depth: int = 0) -> None:
-        nonlocal nodes
-        nodes += 1
-        if nodes > max_nodes or depth > max_depth:
-            raise CanonicalJSONError("JSON structural limit exceeded")
-        if isinstance(item, float):
-            if not math.isfinite(item) or item == 0.0 or item != int(item):
-                raise CanonicalJSONError("TAS-CJSON-1 does not permit floating point values")
-        elif isinstance(item, int) and not -(2**53 - 1) <= item <= 2**53 - 1:
-            raise CanonicalJSONError("integer outside TAS-CJSON-1 range")
-        elif isinstance(item, str):
-            if any(0xD800 <= ord(character) <= 0xDFFF for character in item):
-                raise CanonicalJSONError("Unicode surrogate not permitted")
-        elif isinstance(item, Mapping):
-            for key, child in item.items():
-                if not isinstance(key, str):
-                    raise CanonicalJSONError("JSON object key is not a string")
-                validate(key, depth + 1)
-                validate(child, depth + 1)
-        elif isinstance(item, list):
-            for child in item:
-                validate(child, depth + 1)
-    validate(value)
-    return value
-
-
-def canonical_json(value: Any) -> bytes:
-    """Serialize validated TAS-CJSON-1 data as deterministic UTF-8 bytes."""
-    # Round trip through the validator to apply the same limits/types to local data.
-    provisional = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True,
-                             allow_nan=False).encode("utf-8")
-    parse_canonical_json(provisional)
-    return provisional
-
-
-def canonical_hash(value: Any) -> str:
-    return hashlib.sha256(canonical_json(value)).hexdigest()
+_SECP256K1_ORDER = (
+    0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+)
 
 
 @dataclass(frozen=True)
@@ -111,40 +53,83 @@ class AuthoritySnapshot:
     scope_policy_hash: str
     checkpoint_hash: str
     valid_until: str
+    context_snapshot_hash: str | None = None
+
+
+def authority_binding_hash(snapshot: AuthoritySnapshot) -> str:
+    """Hash the non-circular authority projection committed by a context.
+
+    ``context_snapshot_hash`` is excluded: the context commits to this
+    projection while the full AuthoritySnapshot separately commits back to the
+    context hash. This creates mutual binding without a hash cycle.
+    """
+    body = {
+        "credential_id": snapshot.credential_id,
+        "algorithm": snapshot.algorithm,
+        "public_key": base64.b64encode(snapshot.public_key).decode(),
+        "authority_epoch": snapshot.authority_epoch,
+        "revoked": snapshot.revoked,
+        "scope_policy_hash": snapshot.scope_policy_hash,
+        "checkpoint_hash": snapshot.checkpoint_hash,
+        "valid_until": snapshot.valid_until,
+    }
+    return domain_hash(AUTHORITY_BINDING_DOMAIN, body)
 
 
 class AuthorityResolver(Protocol):
-    def resolve(self, *, credential_id: str, checkpoint_hash: str) -> AuthoritySnapshot | None: ...
+    def resolve(
+        self, *, credential_id: str, checkpoint_hash: str
+    ) -> AuthoritySnapshot | None: ...
 
 
 class SignatureVerifier(Protocol):
-    def verify_signature(self, *, algorithm: str, public_key: bytes, message: bytes,
-                         signature: bytes) -> bool: ...
+    def verify_signature(
+        self,
+        *,
+        algorithm: str,
+        public_key: bytes,
+        message: bytes,
+        signature: bytes,
+    ) -> bool: ...
 
 
 class ReceiptSigner(Protocol):
     @property
     def algorithm(self) -> str: ...
+
     @property
     def public_key(self) -> bytes: ...
+
     def sign(self, message: bytes) -> bytes: ...
 
 
 class DecisionLedger(Protocol):
-    def append_decision(self, receipt_hash: str, receipt: Mapping[str, Any]) -> None: ...
+    def append_decision(
+        self, receipt_hash: str, receipt: Mapping[str, Any]
+    ) -> None: ...
+
     def get_receipt(self, receipt_hash: str) -> Mapping[str, Any] | None: ...
 
 
 class Secp256k1Verifier:
-    """DER ECDSA/SHA-256 verifier for compressed SEC1 public keys and low-S signatures."""
+    """DER ECDSA/SHA-256 verifier for compressed SEC1 keys and low-S signatures."""
+
     algorithm = "ECDSA-secp256k1-SHA256-DER-lowS"
 
-    def verify_signature(self, *, algorithm: str, public_key: bytes, message: bytes,
-                         signature: bytes) -> bool:
+    def verify_signature(
+        self,
+        *,
+        algorithm: str,
+        public_key: bytes,
+        message: bytes,
+        signature: bytes,
+    ) -> bool:
         if algorithm != self.algorithm or len(public_key) != 33:
             return False
         try:
-            key = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256K1(), public_key)
+            key = ec.EllipticCurvePublicKey.from_encoded_point(
+                ec.SECP256K1(), public_key
+            )
             _r, s = decode_dss_signature(signature)
             if not 0 < s <= _SECP256K1_ORDER // 2:
                 return False
@@ -156,43 +141,61 @@ class Secp256k1Verifier:
 
 class LocalSecp256k1Signer:
     """Private-key-backed signer suitable for a KMS/HSM adapter replacement."""
+
     algorithm = Secp256k1Verifier.algorithm
+
     def __init__(self, private_key: ec.EllipticCurvePrivateKey) -> None:
         if not isinstance(private_key.curve, ec.SECP256K1):
             raise ValueError("receipt signer requires a secp256k1 private key")
         self._private_key = private_key
+
     @property
     def public_key(self) -> bytes:
-        return self._private_key.public_key().public_bytes(Encoding.X962, PublicFormat.CompressedPoint)
+        return self._private_key.public_key().public_bytes(
+            Encoding.X962, PublicFormat.CompressedPoint
+        )
+
     def sign(self, message: bytes) -> bytes:
-        r, s = decode_dss_signature(self._private_key.sign(message, ec.ECDSA(hashes.SHA256())))
-        # cryptography emits DER; normalize the mathematically equivalent high-S form.
-        from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+        r, s = decode_dss_signature(
+            self._private_key.sign(message, ec.ECDSA(hashes.SHA256()))
+        )
+        from cryptography.hazmat.primitives.asymmetric.utils import (
+            encode_dss_signature,
+        )
+
         return encode_dss_signature(r, min(s, _SECP256K1_ORDER - s))
 
 
 class InMemoryDecisionLedger:
-    """Test/development append-only reader; production implementations must be durable."""
+    """Test/development append-only reader; production stores must be durable."""
+
     def __init__(self) -> None:
         self._records: dict[str, Mapping[str, Any]] = {}
-    def append_decision(self, receipt_hash: str, receipt: Mapping[str, Any]) -> None:
+
+    def append_decision(
+        self, receipt_hash: str, receipt: Mapping[str, Any]
+    ) -> None:
         if receipt_hash in self._records:
             raise ValueError("receipt hash already recorded")
         self._records[receipt_hash] = dict(receipt)
+
     def get_receipt(self, receipt_hash: str) -> Mapping[str, Any] | None:
         receipt = self._records.get(receipt_hash)
         return dict(receipt) if receipt else None
 
 
 class AuthenticatedLineageVerifier:
-    """Verify bounded, signed receipt ancestry from a ledger reader.
+    """Verify bounded, signed receipt ancestry from a ledger reader."""
 
-    The store is intentionally a read-only protocol boundary.  Production
-    deployments should back it with an append-only service rather than the
-    in-memory implementation above.
-    """
-    def __init__(self, store: DecisionLedger, verifier: SignatureVerifier, max_depth: int = 128) -> None:
-        self._store, self._verifier, self._max_depth = store, verifier, max_depth
+    def __init__(
+        self,
+        store: DecisionLedger,
+        verifier: SignatureVerifier,
+        max_depth: int = 128,
+    ) -> None:
+        self._store = store
+        self._verifier = verifier
+        self._max_depth = max_depth
 
     def verify(self, receipt_hash: str) -> bool:
         seen: set[str] = set()
@@ -203,9 +206,16 @@ class AuthenticatedLineageVerifier:
                 return False
             seen.add(current_hash)
             receipt = self._store.get_receipt(current_hash)
-            if receipt is None or canonical_hash(receipt) != current_hash or not self._valid_signature(receipt):
+            if (
+                receipt is None
+                or canonical_hash(receipt) != current_hash
+                or not self._valid_signature(receipt)
+            ):
                 return False
-            if child is not None and child.get("sequence") != receipt.get("sequence", -1) + 1:
+            if (
+                child is not None
+                and child.get("sequence") != receipt.get("sequence", -1) + 1
+            ):
                 return False
             parent = receipt.get("parent_receipt_hash")
             if parent is None:
@@ -218,76 +228,244 @@ class AuthenticatedLineageVerifier:
     def _valid_signature(self, receipt: Mapping[str, Any]) -> bool:
         try:
             signature = base64.b64decode(receipt["signature"], validate=True)
-            public_key = base64.b64decode(receipt["gatekeeper_public_key"], validate=True)
-            body = {key: value for key, value in receipt.items()
-                    if key not in {"signature", "signature_algorithm", "gatekeeper_public_key"}}
-            return self._verifier.verify_signature(algorithm=receipt["signature_algorithm"], public_key=public_key,
-                                                   message=RECEIPT_DOMAIN + canonical_json(body), signature=signature)
+            public_key = base64.b64decode(
+                receipt["gatekeeper_public_key"], validate=True
+            )
+            body = {
+                key: value
+                for key, value in receipt.items()
+                if key
+                not in {
+                    "signature",
+                    "signature_algorithm",
+                    "gatekeeper_public_key",
+                }
+            }
+            return self._verifier.verify_signature(
+                algorithm=receipt["signature_algorithm"],
+                public_key=public_key,
+                message=RECEIPT_DOMAIN + canonical_json(body),
+                signature=signature,
+            )
         except (KeyError, TypeError, ValueError, CanonicalJSONError):
             return False
 
 
 class AdmissionGatekeeper:
-    """Parse raw requests, bind one authority checkpoint, sign and append decisions."""
-    _FIELDS = frozenset({"schema_version", "canonicalization_version", "domain_separator",
-                         "credential_id", "authority_checkpoint_hash", "authority_epoch",
-                         "signature_algorithm", "requested_operation", "candidate_hash",
-                         "parent_receipt_hash", "nonce", "signature"})
-    def __init__(self, *, gatekeeper_id: str, authority_resolver: AuthorityResolver,
-                 verifier: SignatureVerifier, receipt_signer: ReceiptSigner,
-                 ledger: DecisionLedger) -> None:
-        self.gatekeeper_id, self.authority_resolver = gatekeeper_id, authority_resolver
-        self.verifier, self.receipt_signer, self.ledger = verifier, receipt_signer, ledger
+    """Resolve context first, then authenticate, interpret, sign, and append."""
 
-    def evaluate(self, *, raw_candidate: bytes, raw_envelope: bytes, current_time: str) -> dict[str, Any]:
-        """Return only a signed-and-appended decision, otherwise a fail-closed CUTOFF."""
+    _FIELDS = frozenset(
+        {
+            "schema_version",
+            "canonicalization_version",
+            "domain_separator",
+            "credential_id",
+            "authority_checkpoint_hash",
+            "authority_epoch",
+            "context_snapshot_hash",
+            "signature_algorithm",
+            "requested_operation",
+            "candidate_hash",
+            "parent_receipt_hash",
+            "nonce",
+            "signature",
+        }
+    )
+
+    def __init__(
+        self,
+        *,
+        gatekeeper_id: str,
+        authority_resolver: AuthorityResolver,
+        context_resolver: ContextResolver,
+        definition_resolver: DefinitionResolver,
+        verifier: SignatureVerifier,
+        receipt_signer: ReceiptSigner,
+        ledger: DecisionLedger,
+    ) -> None:
+        self.gatekeeper_id = gatekeeper_id
+        self.authority_resolver = authority_resolver
+        self.context_resolver = context_resolver
+        self.definition_resolver = definition_resolver
+        self.verifier = verifier
+        self.receipt_signer = receipt_signer
+        self.ledger = ledger
+
+    def evaluate(
+        self, *, raw_candidate: bytes, raw_envelope: bytes, current_time: str
+    ) -> dict[str, Any]:
+        """Return only a signed-and-appended decision, otherwise fail closed."""
+        envelope: Mapping[str, Any] = {}
+        snapshot: AuthoritySnapshot | None = None
+        context: ContextSnapshot | None = None
+        candidate: Any = None
+        admitted = False
+        failure: str | None = None
+        raw_candidate_hash = (
+            hashlib.sha256(raw_candidate).hexdigest()
+            if isinstance(raw_candidate, bytes)
+            else None
+        )
+
         try:
-            candidate, envelope = parse_canonical_json(raw_candidate), parse_canonical_json(raw_envelope)
-            if not isinstance(envelope, dict) or set(envelope) != self._FIELDS:
-                raise ValueError("invalid envelope field set")
-            if envelope["schema_version"] != 1 or envelope["canonicalization_version"] != CANONICALIZATION_VERSION:
-                raise ValueError("unsupported envelope version")
-            if envelope["domain_separator"] != "TAS_AUTHORITY_GATE_V1":
-                raise ValueError("invalid authorization domain")
-            if not all(isinstance(envelope[field], str) and envelope[field] for field in
-                       ("credential_id", "signature_algorithm", "requested_operation", "signature", "nonce")):
-                raise ValueError("invalid string envelope field")
-            if (not isinstance(envelope["authority_epoch"], int) or isinstance(envelope["authority_epoch"], bool)
-                    or not _HEX_64.fullmatch(envelope["authority_checkpoint_hash"])
-                    or not _HEX_64.fullmatch(envelope["candidate_hash"])
-                    or (envelope["parent_receipt_hash"] is not None
-                        and (not isinstance(envelope["parent_receipt_hash"], str)
-                             or not _HEX_64.fullmatch(envelope["parent_receipt_hash"])))):
-                raise ValueError("invalid envelope identifier field")
-            if not isinstance(envelope["nonce"], str) or not envelope["nonce"]:
-                raise ValueError("invalid nonce")
-            if envelope["candidate_hash"] != canonical_hash(candidate):
-                raise ValueError("candidate binding mismatch")
-            snapshot = self.authority_resolver.resolve(
-                credential_id=envelope["credential_id"], checkpoint_hash=envelope["authority_checkpoint_hash"])
-            admitted = self._authorized(envelope, snapshot, current_time)
-            failure = None if admitted else "AUTHORIZATION_REFUSED"
-        except Exception as error:
-            envelope, snapshot, admitted, failure = {}, None, False, f"INVALID_INPUT:{type(error).__name__}"
-            candidate = None
-        return self._record(envelope, snapshot, candidate, current_time, admitted, failure)
+            envelope = parse_canonical_json(raw_envelope)
+            self._validate_envelope(envelope)
 
-    def _authorized(self, envelope: Mapping[str, Any], snapshot: AuthoritySnapshot | None,
-                    current_time: str) -> bool:
-        if snapshot is None or snapshot.revoked or envelope["authority_epoch"] != snapshot.authority_epoch:
+            # No candidate semantics are interpreted before context verification.
+            context = resolve_verified_context(
+                context_snapshot_hash=envelope["context_snapshot_hash"],
+                context_resolver=self.context_resolver,
+                definition_resolver=self.definition_resolver,
+            )
+
+            snapshot = self.authority_resolver.resolve(
+                credential_id=envelope["credential_id"],
+                checkpoint_hash=envelope["authority_checkpoint_hash"],
+            )
+            if not self._context_authority_valid(envelope, context, snapshot):
+                failure = "CONTEXT_AUTHORITY_MISMATCH"
+            elif not self._context_lineage_valid(envelope, context):
+                failure = "CONTEXT_LINEAGE_REFUSED"
+            else:
+                candidate = parse_canonical_json(raw_candidate)
+                if envelope["candidate_hash"] != canonical_hash(candidate):
+                    raise ValueError("candidate binding mismatch")
+                admitted = self._authorized(envelope, snapshot, current_time)
+                failure = None if admitted else "AUTHORIZATION_REFUSED"
+        except ContextValidationError:
+            failure = "CONTEXT_REFUSED"
+        except Exception as error:
+            failure = f"INVALID_INPUT:{type(error).__name__}"
+
+        return self._record(
+            envelope=envelope,
+            snapshot=snapshot,
+            context=context,
+            candidate=candidate,
+            raw_candidate_hash=raw_candidate_hash,
+            current_time=current_time,
+            admitted=admitted,
+            failure=failure,
+        )
+
+    def _validate_envelope(self, envelope: Any) -> None:
+        if not isinstance(envelope, dict) or set(envelope) != self._FIELDS:
+            raise ValueError("invalid envelope field set")
+        if (
+            envelope["schema_version"] != 2
+            or envelope["canonicalization_version"]
+            != CANONICALIZATION_VERSION
+        ):
+            raise ValueError("unsupported envelope version")
+        if envelope["domain_separator"] != "TAS_AUTHORITY_GATE_V1":
+            raise ValueError("invalid authorization domain")
+        string_fields = (
+            "credential_id",
+            "signature_algorithm",
+            "requested_operation",
+            "signature",
+            "nonce",
+        )
+        if not all(
+            isinstance(envelope[field], str) and envelope[field]
+            for field in string_fields
+        ):
+            raise ValueError("invalid string envelope field")
+        if (
+            not isinstance(envelope["authority_epoch"], int)
+            or isinstance(envelope["authority_epoch"], bool)
+            or not _HEX_64.fullmatch(envelope["authority_checkpoint_hash"])
+            or not _HEX_64.fullmatch(envelope["context_snapshot_hash"])
+            or not _HEX_64.fullmatch(envelope["candidate_hash"])
+            or (
+                envelope["parent_receipt_hash"] is not None
+                and (
+                    not isinstance(envelope["parent_receipt_hash"], str)
+                    or not _HEX_64.fullmatch(envelope["parent_receipt_hash"])
+                )
+            )
+        ):
+            raise ValueError("invalid envelope identifier field")
+
+    def _context_authority_valid(
+        self,
+        envelope: Mapping[str, Any],
+        context: ContextSnapshot,
+        snapshot: AuthoritySnapshot | None,
+    ) -> bool:
+        if snapshot is None:
             return False
-        if envelope["signature_algorithm"] != snapshot.algorithm or current_time > snapshot.valid_until:
+        return (
+            snapshot.context_snapshot_hash == context.context_snapshot_hash
+            and snapshot.context_snapshot_hash
+            == envelope["context_snapshot_hash"]
+            and snapshot.checkpoint_hash
+            == envelope["authority_checkpoint_hash"]
+            and snapshot.authority_epoch == context.effective_epoch
+            and context.authority_binding_hash
+            == authority_binding_hash(snapshot)
+        )
+
+    def _context_lineage_valid(
+        self, envelope: Mapping[str, Any], context: ContextSnapshot
+    ) -> bool:
+        parent_hash = envelope["parent_receipt_hash"]
+        if parent_hash is None:
+            return True
+        parent = self.ledger.get_receipt(parent_hash)
+        if parent is None:
+            return False
+        parent_context_hash = parent.get("context_snapshot_hash")
+        return parent_context_hash in {
+            context.context_snapshot_hash,
+            context.parent_context_hash,
+        }
+
+    def _authorized(
+        self,
+        envelope: Mapping[str, Any],
+        snapshot: AuthoritySnapshot | None,
+        current_time: str,
+    ) -> bool:
+        if (
+            snapshot is None
+            or snapshot.revoked
+            or envelope["authority_epoch"] != snapshot.authority_epoch
+        ):
+            return False
+        if (
+            envelope["signature_algorithm"] != snapshot.algorithm
+            or current_time > snapshot.valid_until
+        ):
             return False
         try:
             signature = base64.b64decode(envelope["signature"], validate=True)
         except (ValueError, TypeError):
             return False
-        body = {key: value for key, value in envelope.items() if key != "signature"}
-        return self.verifier.verify_signature(algorithm=snapshot.algorithm, public_key=snapshot.public_key,
-                                              message=AUTHORIZATION_DOMAIN + canonical_json(body), signature=signature)
+        body = {
+            key: value
+            for key, value in envelope.items()
+            if key != "signature"
+        }
+        return self.verifier.verify_signature(
+            algorithm=snapshot.algorithm,
+            public_key=snapshot.public_key,
+            message=AUTHORIZATION_DOMAIN + canonical_json(body),
+            signature=signature,
+        )
 
-    def _record(self, envelope: Mapping[str, Any], snapshot: AuthoritySnapshot | None, candidate: Any,
-                current_time: str, admitted: bool, failure: str | None) -> dict[str, Any]:
+    def _record(
+        self,
+        *,
+        envelope: Mapping[str, Any],
+        snapshot: AuthoritySnapshot | None,
+        context: ContextSnapshot | None,
+        candidate: Any,
+        raw_candidate_hash: str | None,
+        current_time: str,
+        admitted: bool,
+        failure: str | None,
+    ) -> dict[str, Any]:
         parent_hash = envelope.get("parent_receipt_hash")
         try:
             if parent_hash is None:
@@ -298,29 +476,85 @@ class AdmissionGatekeeper:
                     raise ValueError("unknown lineage parent")
                 sequence = parent["sequence"] + 1
         except Exception:
-            return {"resulting_state": "CUTOFF", "failure_code": "LINEAGE_UNAVAILABLE", "durable_receipt": False}
-        body = {"schema_version": 1, "canonicalization_version": CANONICALIZATION_VERSION,
-                "rule_set_version": RULE_SET_VERSION, "gatekeeper_id": self.gatekeeper_id,
-                "event_type": "ADMISSION_DECISION", "evaluated_at": current_time, "sequence": sequence,
-                "decision_id": hashlib.sha256((str(envelope.get("nonce")) + str(envelope.get("candidate_hash")) + current_time).encode()).hexdigest(),
-                "resulting_state": "ADMITTED" if admitted else "REFUSED",
-                "credential_id": envelope.get("credential_id"),
-                "authority_epoch": snapshot.authority_epoch if snapshot else None,
-                "authority_checkpoint_hash": snapshot.checkpoint_hash if snapshot else None,
-                "candidate_hash": canonical_hash(candidate) if candidate is not None else None,
-                "authorization_envelope_hash": canonical_hash(envelope) if envelope else None,
-                "requested_operation": envelope.get("requested_operation"),
-                "parent_receipt_hash": envelope.get("parent_receipt_hash"), "nonce": envelope.get("nonce"),
-                "failure_code": failure}
+            return {
+                "resulting_state": "CUTOFF",
+                "failure_code": "LINEAGE_UNAVAILABLE",
+                "durable_receipt": False,
+            }
+
+        decision_material = {
+            "nonce": envelope.get("nonce"),
+            "declared_candidate_hash": envelope.get("candidate_hash"),
+            "context_snapshot_hash": envelope.get("context_snapshot_hash"),
+            "evaluated_at": current_time,
+        }
+        body = {
+            "schema_version": 2,
+            "canonicalization_version": CANONICALIZATION_VERSION,
+            "rule_set_version": RULE_SET_VERSION,
+            "gatekeeper_id": self.gatekeeper_id,
+            "event_type": "ADMISSION_DECISION",
+            "evaluated_at": current_time,
+            "sequence": sequence,
+            "decision_id": canonical_hash(decision_material),
+            "resulting_state": "ADMITTED" if admitted else "REFUSED",
+            "credential_id": envelope.get("credential_id"),
+            "authority_epoch": (
+                snapshot.authority_epoch if snapshot else None
+            ),
+            "authority_checkpoint_hash": (
+                snapshot.checkpoint_hash if snapshot else None
+            ),
+            "context_snapshot_hash": (
+                context.context_snapshot_hash
+                if context is not None
+                else envelope.get("context_snapshot_hash")
+            ),
+            "context_parent_hash": (
+                context.parent_context_hash if context else None
+            ),
+            "namespace_id": context.namespace_id if context else None,
+            "registry_root": context.registry_root if context else None,
+            "invariant_set_id": context.invariant_set_id if context else None,
+            "authority_binding_hash": (
+                context.authority_binding_hash if context else None
+            ),
+            "candidate_hash": (
+                canonical_hash(candidate) if candidate is not None else None
+            ),
+            "declared_candidate_hash": envelope.get("candidate_hash"),
+            "candidate_bytes_hash": raw_candidate_hash,
+            "authorization_envelope_hash": (
+                canonical_hash(envelope) if envelope else None
+            ),
+            "requested_operation": envelope.get("requested_operation"),
+            "parent_receipt_hash": parent_hash,
+            "nonce": envelope.get("nonce"),
+            "failure_code": failure,
+        }
         try:
-            signature = self.receipt_signer.sign(RECEIPT_DOMAIN + canonical_json(body))
-            receipt = {**body, "signature_algorithm": self.receipt_signer.algorithm,
-                       "gatekeeper_public_key": base64.b64encode(self.receipt_signer.public_key).decode(),
-                       "signature": base64.b64encode(signature).decode()}
+            signature = self.receipt_signer.sign(
+                RECEIPT_DOMAIN + canonical_json(body)
+            )
+            receipt = {
+                **body,
+                "signature_algorithm": self.receipt_signer.algorithm,
+                "gatekeeper_public_key": base64.b64encode(
+                    self.receipt_signer.public_key
+                ).decode(),
+                "signature": base64.b64encode(signature).decode(),
+            }
             receipt_hash = canonical_hash(receipt)
             self.ledger.append_decision(receipt_hash, receipt)
-            return {"resulting_state": body["resulting_state"], "durable_receipt": True,
-                    "receipt_hash": receipt_hash, "receipt": receipt}
+            return {
+                "resulting_state": body["resulting_state"],
+                "durable_receipt": True,
+                "receipt_hash": receipt_hash,
+                "receipt": receipt,
+            }
         except Exception:
-            return {"resulting_state": "CUTOFF", "failure_code": "RECEIPT_PRESERVATION_UNAVAILABLE",
-                    "durable_receipt": False}
+            return {
+                "resulting_state": "CUTOFF",
+                "failure_code": "RECEIPT_PRESERVATION_UNAVAILABLE",
+                "durable_receipt": False,
+            }

--- a/context_snapshot.py
+++ b/context_snapshot.py
@@ -1,0 +1,461 @@
+"""Content-addressed semantic context for TAS admission decisions.
+
+The context snapshot pins the dictionary, invariant set, authority projection,
+canonicalization rules, namespace, and predecessor context used to interpret a
+candidate. Context and definition objects are accepted only as exact
+TAS-CJSON-1 bytes; mutable aliases and non-canonical encodings fail closed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol, Sequence
+
+CANONICALIZATION_VERSION = "TAS-CJSON-1"
+CONTEXT_SCHEMA_VERSION = "tas.context-snapshot.v1"
+DEFINITION_SCHEMA_VERSION = "tas.definition.v1"
+CONTEXT_SNAPSHOT_DOMAIN = b"TAS-CONTEXT-SNAPSHOT-V1\x00"
+CONTEXT_REGISTRY_DOMAIN = b"TAS-CONTEXT-REGISTRY-V1\x00"
+DEFINITION_DOMAIN = b"TAS-DEFINITION-V1\x00"
+_HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class CanonicalJSONError(ValueError):
+    """Raised when input is outside the constrained TAS-CJSON-1 subset."""
+
+
+class ContextValidationError(ValueError):
+    """Raised when semantic context or definition integrity fails."""
+
+
+def _reject_duplicates(pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise CanonicalJSONError(f"duplicate JSON key: {key!r}")
+        result[key] = value
+    return result
+
+
+def parse_canonical_json(
+    raw: bytes,
+    *,
+    max_bytes: int = 65536,
+    max_depth: int = 32,
+    max_nodes: int = 4096,
+) -> Any:
+    """Decode UTF-8 JSON after rejecting ambiguous and non-portable forms."""
+    if not isinstance(raw, bytes) or len(raw) > max_bytes:
+        raise CanonicalJSONError("JSON input exceeds byte limit")
+    try:
+        value = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_reject_duplicates,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                CanonicalJSONError(f"invalid JSON constant: {value}")
+            ),
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise CanonicalJSONError("invalid UTF-8 JSON") from error
+
+    nodes = 0
+
+    def validate(item: Any, depth: int = 0) -> None:
+        nonlocal nodes
+        nodes += 1
+        if nodes > max_nodes or depth > max_depth:
+            raise CanonicalJSONError("JSON structural limit exceeded")
+        if isinstance(item, float):
+            raise CanonicalJSONError(
+                "TAS-CJSON-1 does not permit floating point values"
+            )
+        if isinstance(item, int) and not -(2**53 - 1) <= item <= 2**53 - 1:
+            raise CanonicalJSONError("integer outside TAS-CJSON-1 range")
+        if isinstance(item, str):
+            if any(0xD800 <= ord(character) <= 0xDFFF for character in item):
+                raise CanonicalJSONError("Unicode surrogate not permitted")
+        elif isinstance(item, Mapping):
+            for key, child in item.items():
+                if not isinstance(key, str):
+                    raise CanonicalJSONError("JSON object key is not a string")
+                validate(key, depth + 1)
+                validate(child, depth + 1)
+        elif isinstance(item, list):
+            for child in item:
+                validate(child, depth + 1)
+
+    validate(value)
+    return value
+
+
+def canonical_json(value: Any) -> bytes:
+    """Serialize TAS-CJSON-1 data as deterministic UTF-8 bytes."""
+    provisional = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    parse_canonical_json(provisional)
+    return provisional
+
+
+def canonical_hash(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value)).hexdigest()
+
+
+def domain_hash(domain: bytes, value: Any) -> str:
+    return hashlib.sha256(domain + canonical_json(value)).hexdigest()
+
+
+def _require_hex64(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not _HEX_64.fullmatch(value):
+        raise ContextValidationError(
+            f"{field} must be a lowercase SHA-256 hex digest"
+        )
+    return value
+
+
+def _require_nonempty_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ContextValidationError(f"{field} must be a non-empty string")
+    return value
+
+
+def _validate_definition_mapping(definition: Mapping[str, Any]) -> None:
+    fields = {
+        "schema_version",
+        "canonicalization_version",
+        "namespace_id",
+        "term",
+        "semantic_version",
+        "definition",
+        "constraints",
+        "supersedes",
+    }
+    if set(definition) != fields:
+        raise ContextValidationError("invalid definition record field set")
+    if definition["schema_version"] != DEFINITION_SCHEMA_VERSION:
+        raise ContextValidationError("unsupported definition schema version")
+    if definition["canonicalization_version"] != CANONICALIZATION_VERSION:
+        raise ContextValidationError("unsupported definition canonicalization")
+    _require_nonempty_string(definition["namespace_id"], "namespace_id")
+    _require_nonempty_string(definition["term"], "term")
+    _require_nonempty_string(definition["semantic_version"], "semantic_version")
+    _require_nonempty_string(definition["definition"], "definition")
+    if not isinstance(definition["constraints"], list):
+        raise ContextValidationError("constraints must be an array")
+    supersedes = definition["supersedes"]
+    if supersedes is not None:
+        _require_hex64(supersedes, "supersedes")
+
+
+def definition_id_for_mapping(definition: Mapping[str, Any]) -> str:
+    """Return the domain-separated identifier for a definition record."""
+    _validate_definition_mapping(definition)
+    return domain_hash(DEFINITION_DOMAIN, definition)
+
+
+def definition_id_for_raw(raw: bytes) -> str:
+    definition = parse_canonical_json(raw)
+    if canonical_json(definition) != raw:
+        raise ContextValidationError(
+            "definition bytes are not canonical TAS-CJSON-1"
+        )
+    if not isinstance(definition, Mapping):
+        raise ContextValidationError("definition record must be an object")
+    return definition_id_for_mapping(definition)
+
+
+def registry_root_for(definition_ids: Sequence[str]) -> str:
+    """Commit to the exact declared order of DefinitionIDs."""
+    identifiers = list(definition_ids)
+    if not identifiers:
+        raise ContextValidationError("definition_ids must not be empty")
+    if len(set(identifiers)) != len(identifiers):
+        raise ContextValidationError("definition_ids must not contain duplicates")
+    for identifier in identifiers:
+        _require_hex64(identifier, "definition_id")
+    return domain_hash(CONTEXT_REGISTRY_DOMAIN, identifiers)
+
+
+def make_definition_record(
+    *,
+    namespace_id: str,
+    term: str,
+    semantic_version: str,
+    definition: str,
+    constraints: Sequence[Any] = (),
+    supersedes: str | None = None,
+) -> dict[str, Any]:
+    record = {
+        "schema_version": DEFINITION_SCHEMA_VERSION,
+        "canonicalization_version": CANONICALIZATION_VERSION,
+        "namespace_id": namespace_id,
+        "term": term,
+        "semantic_version": semantic_version,
+        "definition": definition,
+        "constraints": list(constraints),
+        "supersedes": supersedes,
+    }
+    _validate_definition_mapping(record)
+    return record
+
+
+@dataclass(frozen=True)
+class ContextSnapshot:
+    schema_version: str
+    canonicalization_version: str
+    namespace_id: str
+    context_sequence: int
+    registry_root: str
+    definition_ids: tuple[str, ...]
+    invariant_set_id: str
+    authority_binding_hash: str
+    parent_context_hash: str | None
+    effective_epoch: int
+    context_snapshot_hash: str
+
+    @property
+    def unsigned_mapping(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "canonicalization_version": self.canonicalization_version,
+            "namespace_id": self.namespace_id,
+            "context_sequence": self.context_sequence,
+            "registry_root": self.registry_root,
+            "definition_ids": list(self.definition_ids),
+            "invariant_set_id": self.invariant_set_id,
+            "authority_binding_hash": self.authority_binding_hash,
+            "parent_context_hash": self.parent_context_hash,
+            "effective_epoch": self.effective_epoch,
+        }
+
+    @property
+    def mapping(self) -> dict[str, Any]:
+        return {
+            **self.unsigned_mapping,
+            "context_snapshot_hash": self.context_snapshot_hash,
+        }
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        namespace_id: str,
+        context_sequence: int,
+        definition_ids: Sequence[str],
+        invariant_set_id: str,
+        authority_binding_hash: str,
+        parent_context_hash: str | None,
+        effective_epoch: int,
+    ) -> "ContextSnapshot":
+        unsigned = {
+            "schema_version": CONTEXT_SCHEMA_VERSION,
+            "canonicalization_version": CANONICALIZATION_VERSION,
+            "namespace_id": namespace_id,
+            "context_sequence": context_sequence,
+            "registry_root": registry_root_for(definition_ids),
+            "definition_ids": list(definition_ids),
+            "invariant_set_id": invariant_set_id,
+            "authority_binding_hash": authority_binding_hash,
+            "parent_context_hash": parent_context_hash,
+            "effective_epoch": effective_epoch,
+        }
+        snapshot_hash = domain_hash(CONTEXT_SNAPSHOT_DOMAIN, unsigned)
+        return cls.from_mapping({**unsigned, "context_snapshot_hash": snapshot_hash})
+
+    @classmethod
+    def from_raw(cls, raw: bytes) -> "ContextSnapshot":
+        value = parse_canonical_json(raw)
+        if canonical_json(value) != raw:
+            raise ContextValidationError(
+                "context snapshot bytes are not canonical TAS-CJSON-1"
+            )
+        if not isinstance(value, Mapping):
+            raise ContextValidationError("context snapshot must be an object")
+        return cls.from_mapping(value)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "ContextSnapshot":
+        fields = {
+            "schema_version",
+            "canonicalization_version",
+            "namespace_id",
+            "context_sequence",
+            "registry_root",
+            "definition_ids",
+            "invariant_set_id",
+            "authority_binding_hash",
+            "parent_context_hash",
+            "effective_epoch",
+            "context_snapshot_hash",
+        }
+        if set(value) != fields:
+            raise ContextValidationError("invalid context snapshot field set")
+        if value["schema_version"] != CONTEXT_SCHEMA_VERSION:
+            raise ContextValidationError("unsupported context schema version")
+        if value["canonicalization_version"] != CANONICALIZATION_VERSION:
+            raise ContextValidationError("unsupported context canonicalization")
+        namespace_id = _require_nonempty_string(
+            value["namespace_id"], "namespace_id"
+        )
+        sequence = value["context_sequence"]
+        epoch = value["effective_epoch"]
+        if (
+            not isinstance(sequence, int)
+            or isinstance(sequence, bool)
+            or sequence < 0
+            or not isinstance(epoch, int)
+            or isinstance(epoch, bool)
+            or epoch < 0
+        ):
+            raise ContextValidationError(
+                "context sequence and epoch must be non-negative integers"
+            )
+        identifiers = value["definition_ids"]
+        if not isinstance(identifiers, list):
+            raise ContextValidationError("definition_ids must be an array")
+        definition_ids = tuple(identifiers)
+        registry_root = _require_hex64(value["registry_root"], "registry_root")
+        if registry_root != registry_root_for(definition_ids):
+            raise ContextValidationError(
+                "registry_root does not commit to definition_ids"
+            )
+        invariant_set_id = _require_hex64(
+            value["invariant_set_id"], "invariant_set_id"
+        )
+        authority_binding_hash = _require_hex64(
+            value["authority_binding_hash"], "authority_binding_hash"
+        )
+        parent = value["parent_context_hash"]
+        if sequence == 0:
+            if parent is not None:
+                raise ContextValidationError(
+                    "genesis context must have a null parent"
+                )
+        else:
+            parent = _require_hex64(parent, "parent_context_hash")
+        declared_hash = _require_hex64(
+            value["context_snapshot_hash"], "context_snapshot_hash"
+        )
+        unsigned = {
+            key: value[key]
+            for key in fields
+            if key != "context_snapshot_hash"
+        }
+        computed_hash = domain_hash(CONTEXT_SNAPSHOT_DOMAIN, unsigned)
+        if declared_hash != computed_hash:
+            raise ContextValidationError("context_snapshot_hash mismatch")
+        return cls(
+            schema_version=value["schema_version"],
+            canonicalization_version=value["canonicalization_version"],
+            namespace_id=namespace_id,
+            context_sequence=sequence,
+            registry_root=registry_root,
+            definition_ids=definition_ids,
+            invariant_set_id=invariant_set_id,
+            authority_binding_hash=authority_binding_hash,
+            parent_context_hash=parent,
+            effective_epoch=epoch,
+            context_snapshot_hash=declared_hash,
+        )
+
+
+class ContextResolver(Protocol):
+    def resolve(self, *, context_snapshot_hash: str) -> bytes | None: ...
+
+    def expected_head(self, *, namespace_id: str) -> str | None: ...
+
+
+class DefinitionResolver(Protocol):
+    def resolve(self, *, definition_id: str) -> bytes | None: ...
+
+
+class InMemoryContextResolver:
+    """Test/development resolver for snapshots and namespace heads."""
+
+    def __init__(
+        self,
+        snapshots: Mapping[str, bytes],
+        namespace_heads: Mapping[str, str],
+    ) -> None:
+        self._snapshots = dict(snapshots)
+        self._namespace_heads = dict(namespace_heads)
+
+    def resolve(self, *, context_snapshot_hash: str) -> bytes | None:
+        return self._snapshots.get(context_snapshot_hash)
+
+    def expected_head(self, *, namespace_id: str) -> str | None:
+        return self._namespace_heads.get(namespace_id)
+
+
+class InMemoryDefinitionResolver:
+    """Test/development resolver for content-addressed definitions."""
+
+    def __init__(self, definitions: Mapping[str, bytes]) -> None:
+        self._definitions = dict(definitions)
+
+    def resolve(self, *, definition_id: str) -> bytes | None:
+        return self._definitions.get(definition_id)
+
+
+def resolve_verified_context(
+    *,
+    context_snapshot_hash: str,
+    context_resolver: ContextResolver,
+    definition_resolver: DefinitionResolver,
+) -> ContextSnapshot:
+    """Resolve and verify an active context and every pinned definition."""
+    _require_hex64(context_snapshot_hash, "context_snapshot_hash")
+    raw_context = context_resolver.resolve(
+        context_snapshot_hash=context_snapshot_hash
+    )
+    if raw_context is None:
+        raise ContextValidationError("context snapshot is unavailable")
+    try:
+        context = ContextSnapshot.from_raw(raw_context)
+    except (CanonicalJSONError, ContextValidationError) as error:
+        raise ContextValidationError(
+            "context snapshot validation failed"
+        ) from error
+    if context.context_snapshot_hash != context_snapshot_hash:
+        raise ContextValidationError(
+            "resolved context does not match requested hash"
+        )
+    expected_head = context_resolver.expected_head(
+        namespace_id=context.namespace_id
+    )
+    if expected_head != context.context_snapshot_hash:
+        raise ContextValidationError(
+            "context snapshot is not the active namespace head"
+        )
+
+    for identifier in context.definition_ids:
+        raw_definition = definition_resolver.resolve(definition_id=identifier)
+        if raw_definition is None:
+            raise ContextValidationError("pinned definition is unavailable")
+        try:
+            definition = parse_canonical_json(raw_definition)
+            if canonical_json(definition) != raw_definition:
+                raise ContextValidationError(
+                    "definition bytes are not canonical TAS-CJSON-1"
+                )
+            if not isinstance(definition, Mapping):
+                raise ContextValidationError(
+                    "definition record must be an object"
+                )
+            _validate_definition_mapping(definition)
+        except (CanonicalJSONError, ContextValidationError) as error:
+            raise ContextValidationError("definition validation failed") from error
+        if definition["namespace_id"] != context.namespace_id:
+            raise ContextValidationError("definition namespace mismatch")
+        if definition_id_for_mapping(definition) != identifier:
+            raise ContextValidationError(
+                "definition content does not match DefinitionID"
+            )
+    return context

--- a/schemas/tas.context-snapshot.v1.schema.json
+++ b/schemas/tas.context-snapshot.v1.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://truealphaspiral.org/schemas/tas.context-snapshot.v1.schema.json",
+  "title": "TAS Context Snapshot v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "canonicalization_version",
+    "namespace_id",
+    "context_sequence",
+    "registry_root",
+    "definition_ids",
+    "invariant_set_id",
+    "authority_binding_hash",
+    "parent_context_hash",
+    "effective_epoch",
+    "context_snapshot_hash"
+  ],
+  "properties": {
+    "schema_version": {"const": "tas.context-snapshot.v1"},
+    "canonicalization_version": {"const": "TAS-CJSON-1"},
+    "namespace_id": {"type": "string", "minLength": 1},
+    "context_sequence": {"type": "integer", "minimum": 0},
+    "registry_root": {"$ref": "#/$defs/sha256"},
+    "definition_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/sha256"}
+    },
+    "invariant_set_id": {"$ref": "#/$defs/sha256"},
+    "authority_binding_hash": {"$ref": "#/$defs/sha256"},
+    "parent_context_hash": {
+      "oneOf": [
+        {"type": "null"},
+        {"$ref": "#/$defs/sha256"}
+      ]
+    },
+    "effective_epoch": {"type": "integer", "minimum": 0},
+    "context_snapshot_hash": {"$ref": "#/$defs/sha256"}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"context_sequence": {"const": 0}}},
+      "then": {"properties": {"parent_context_hash": {"type": "null"}}},
+      "else": {
+        "properties": {
+          "parent_context_hash": {"$ref": "#/$defs/sha256"}
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  }
+}

--- a/schemas/tas.definition.v1.schema.json
+++ b/schemas/tas.definition.v1.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://truealphaspiral.org/schemas/tas.definition.v1.schema.json",
+  "title": "TAS Definition Record v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "canonicalization_version",
+    "namespace_id",
+    "term",
+    "semantic_version",
+    "definition",
+    "constraints",
+    "supersedes"
+  ],
+  "properties": {
+    "schema_version": {"const": "tas.definition.v1"},
+    "canonicalization_version": {"const": "TAS-CJSON-1"},
+    "namespace_id": {"type": "string", "minLength": 1},
+    "term": {"type": "string", "minLength": 1},
+    "semantic_version": {"type": "string", "minLength": 1},
+    "definition": {"type": "string", "minLength": 1},
+    "constraints": {"type": "array"},
+    "supersedes": {
+      "oneOf": [
+        {"type": "null"},
+        {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      ]
+    }
+  }
+}

--- a/tests/test_admission_gate.py
+++ b/tests/test_admission_gate.py
@@ -1,83 +1,293 @@
 import base64
 import os
 import sys
+from dataclasses import replace
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
-from admission_gate import (AUTHORIZATION_DOMAIN, AdmissionGatekeeper, AuthoritySnapshot,
-                            AuthenticatedLineageVerifier, CANONICALIZATION_VERSION, InMemoryDecisionLedger,
-                            LocalSecp256k1Signer, Secp256k1Verifier, canonical_hash,
-                            canonical_json, parse_canonical_json)
+from admission_gate import (
+    AUTHORIZATION_DOMAIN,
+    AdmissionGatekeeper,
+    AuthoritySnapshot,
+    AuthenticatedLineageVerifier,
+    CANONICALIZATION_VERSION,
+    InMemoryDecisionLedger,
+    LocalSecp256k1Signer,
+    Secp256k1Verifier,
+    authority_binding_hash,
+    canonical_hash,
+    canonical_json,
+    parse_canonical_json,
+)
+from context_snapshot import (
+    ContextSnapshot,
+    InMemoryContextResolver,
+    InMemoryDefinitionResolver,
+    definition_id_for_mapping,
+    make_definition_record,
+)
 
 
 class Resolver:
-    def __init__(self, snapshot): self.snapshot = snapshot
+    def __init__(self, snapshot):
+        self.snapshot = snapshot
+
     def resolve(self, *, credential_id, checkpoint_hash):
-        return self.snapshot if (credential_id, checkpoint_hash) == (self.snapshot.credential_id, self.snapshot.checkpoint_hash) else None
+        return (
+            self.snapshot
+            if (credential_id, checkpoint_hash)
+            == (self.snapshot.credential_id, self.snapshot.checkpoint_hash)
+            else None
+        )
 
 
 def _gate():
-    authority_key, receipt_key = ec.generate_private_key(ec.SECP256K1()), ec.generate_private_key(ec.SECP256K1())
+    authority_key = ec.generate_private_key(ec.SECP256K1())
+    receipt_key = ec.generate_private_key(ec.SECP256K1())
     authority = LocalSecp256k1Signer(authority_key)
-    snapshot = AuthoritySnapshot("credential-1", authority.algorithm, authority.public_key, 7, False,
-                                 "scope", "a" * 64, "2030-01-01T00:00:00Z")
+
+    authority_snapshot = AuthoritySnapshot(
+        "credential-1",
+        authority.algorithm,
+        authority.public_key,
+        7,
+        False,
+        "c" * 64,
+        "a" * 64,
+        "2030-01-01T00:00:00Z",
+    )
+    definition = make_definition_record(
+        namespace_id="tas:core",
+        term="requested_operation",
+        semantic_version="1",
+        definition="The scoped operation requested by external authority.",
+    )
+    definition_id = definition_id_for_mapping(definition)
+    context = ContextSnapshot.build(
+        namespace_id="tas:core",
+        context_sequence=0,
+        definition_ids=[definition_id],
+        invariant_set_id="b" * 64,
+        authority_binding_hash=authority_binding_hash(authority_snapshot),
+        parent_context_hash=None,
+        effective_epoch=7,
+    )
+    authority_snapshot = replace(
+        authority_snapshot,
+        context_snapshot_hash=context.context_snapshot_hash,
+    )
     ledger = InMemoryDecisionLedger()
-    return AdmissionGatekeeper(gatekeeper_id="gate-1", authority_resolver=Resolver(snapshot),
-                               verifier=Secp256k1Verifier(), receipt_signer=LocalSecp256k1Signer(receipt_key), ledger=ledger), authority, ledger
+    context_resolver = InMemoryContextResolver(
+        {context.context_snapshot_hash: canonical_json(context.mapping)},
+        {context.namespace_id: context.context_snapshot_hash},
+    )
+    definition_resolver = InMemoryDefinitionResolver(
+        {definition_id: canonical_json(definition)}
+    )
+    gate = AdmissionGatekeeper(
+        gatekeeper_id="gate-1",
+        authority_resolver=Resolver(authority_snapshot),
+        context_resolver=context_resolver,
+        definition_resolver=definition_resolver,
+        verifier=Secp256k1Verifier(),
+        receipt_signer=LocalSecp256k1Signer(receipt_key),
+        ledger=ledger,
+    )
+    return gate, authority, ledger, context, authority_snapshot
 
 
-def _request(authority, candidate={"operation": "READ"}):
-    body = {"schema_version": 1, "canonicalization_version": CANONICALIZATION_VERSION,
-            "domain_separator": "TAS_AUTHORITY_GATE_V1", "credential_id": "credential-1",
-            "authority_checkpoint_hash": "a" * 64, "authority_epoch": 7,
-            "signature_algorithm": authority.algorithm, "requested_operation": "READ",
-            "candidate_hash": canonical_hash(candidate), "parent_receipt_hash": None, "nonce": "nonce-1"}
-    return canonical_json(candidate), canonical_json({**body, "signature": base64.b64encode(authority.sign(AUTHORIZATION_DOMAIN + canonical_json(body))).decode()})
+def _request(
+    authority,
+    context,
+    candidate=None,
+    parent_receipt_hash=None,
+):
+    if candidate is None:
+        candidate = {"operation": "READ"}
+    body = {
+        "schema_version": 2,
+        "canonicalization_version": CANONICALIZATION_VERSION,
+        "domain_separator": "TAS_AUTHORITY_GATE_V1",
+        "credential_id": "credential-1",
+        "authority_checkpoint_hash": "a" * 64,
+        "authority_epoch": 7,
+        "context_snapshot_hash": context.context_snapshot_hash,
+        "signature_algorithm": authority.algorithm,
+        "requested_operation": "READ",
+        "candidate_hash": canonical_hash(candidate),
+        "parent_receipt_hash": parent_receipt_hash,
+        "nonce": "nonce-1",
+    }
+    signature = base64.b64encode(
+        authority.sign(AUTHORIZATION_DOMAIN + canonical_json(body))
+    ).decode()
+    return canonical_json(candidate), canonical_json(
+        {**body, "signature": signature}
+    )
 
 
-def test_admitted_decision_is_real_signature_and_is_recorded_before_return():
-    gate, authority, ledger = _gate()
-    candidate, envelope = _request(authority)
-    result = gate.evaluate(raw_candidate=candidate, raw_envelope=envelope, current_time="2029-01-01T00:00:00Z")
-    assert result["resulting_state"] == "ADMITTED" and result["durable_receipt"]
+def test_admitted_decision_is_context_bound_and_recorded_before_return():
+    gate, authority, ledger, context, _ = _gate()
+    candidate, envelope = _request(authority, context)
+    result = gate.evaluate(
+        raw_candidate=candidate,
+        raw_envelope=envelope,
+        current_time="2029-01-01T00:00:00Z",
+    )
+    assert result["resulting_state"] == "ADMITTED"
+    assert result["durable_receipt"]
+    assert (
+        result["receipt"]["context_snapshot_hash"]
+        == context.context_snapshot_hash
+    )
+    assert result["receipt"]["registry_root"] == context.registry_root
     assert ledger.get_receipt(result["receipt_hash"]) == result["receipt"]
-    assert AuthenticatedLineageVerifier(ledger, Secp256k1Verifier()).verify(result["receipt_hash"])
+    assert AuthenticatedLineageVerifier(
+        ledger, Secp256k1Verifier()
+    ).verify(result["receipt_hash"])
 
 
 def test_public_key_cannot_forge_authorization_signature():
-    gate, authority, _ = _gate()
-    candidate, envelope = _request(authority)
+    gate, authority, _, context, _ = _gate()
+    candidate, envelope = _request(authority, context)
     forged = parse_canonical_json(envelope)
     forged["signature"] = base64.b64encode(b"not a signature").decode()
-    result = gate.evaluate(raw_candidate=candidate, raw_envelope=canonical_json(forged), current_time="2029-01-01T00:00:00Z")
-    assert result["resulting_state"] == "REFUSED" and result["durable_receipt"]
-
-
-def test_duplicate_key_is_rejected_before_candidate_is_constructed():
-    gate, authority, _ = _gate()
-    _, envelope = _request(authority)
-    result = gate.evaluate(raw_candidate=b'{"operation":"READ","operation":"DELETE"}', raw_envelope=envelope,
-                           current_time="2029-01-01T00:00:00Z")
+    result = gate.evaluate(
+        raw_candidate=candidate,
+        raw_envelope=canonical_json(forged),
+        current_time="2029-01-01T00:00:00Z",
+    )
     assert result["resulting_state"] == "REFUSED"
+    assert result["durable_receipt"]
+
+
+def test_context_is_verified_before_candidate_is_parsed():
+    gate, authority, _, context, _ = _gate()
+    _, envelope = _request(authority, context)
+    gate.context_resolver._namespace_heads[context.namespace_id] = "f" * 64
+    result = gate.evaluate(
+        raw_candidate=b'{"operation":"READ","operation":"DELETE"}',
+        raw_envelope=envelope,
+        current_time="2029-01-01T00:00:00Z",
+    )
+    assert result["resulting_state"] == "REFUSED"
+    assert result["receipt"]["failure_code"] == "CONTEXT_REFUSED"
+    assert result["receipt"]["candidate_hash"] is None
+
+
+def test_authority_snapshot_cannot_swap_context_mid_flight():
+    gate, authority, _, context, snapshot = _gate()
+    candidate, envelope = _request(authority, context)
+    gate.authority_resolver.snapshot = replace(
+        snapshot,
+        context_snapshot_hash="f" * 64,
+    )
+    result = gate.evaluate(
+        raw_candidate=candidate,
+        raw_envelope=envelope,
+        current_time="2029-01-01T00:00:00Z",
+    )
+    assert result["resulting_state"] == "REFUSED"
+    assert (
+        result["receipt"]["failure_code"]
+        == "CONTEXT_AUTHORITY_MISMATCH"
+    )
+
+
+def test_context_lineage_cannot_teleport_across_unrelated_contexts():
+    gate, authority, _, context, snapshot = _gate()
+    candidate, envelope = _request(authority, context)
+    first = gate.evaluate(
+        raw_candidate=candidate,
+        raw_envelope=envelope,
+        current_time="2029-01-01T00:00:00Z",
+    )
+
+    next_context = ContextSnapshot.build(
+        namespace_id=context.namespace_id,
+        context_sequence=1,
+        definition_ids=context.definition_ids,
+        invariant_set_id=context.invariant_set_id,
+        authority_binding_hash=context.authority_binding_hash,
+        parent_context_hash="e" * 64,
+        effective_epoch=7,
+    )
+    gate.context_resolver._snapshots[
+        next_context.context_snapshot_hash
+    ] = canonical_json(next_context.mapping)
+    gate.context_resolver._namespace_heads[next_context.namespace_id] = (
+        next_context.context_snapshot_hash
+    )
+    gate.authority_resolver.snapshot = replace(
+        snapshot,
+        context_snapshot_hash=next_context.context_snapshot_hash,
+    )
+    candidate, envelope = _request(
+        authority,
+        next_context,
+        parent_receipt_hash=first["receipt_hash"],
+    )
+    result = gate.evaluate(
+        raw_candidate=candidate,
+        raw_envelope=envelope,
+        current_time="2029-01-01T00:00:01Z",
+    )
+    assert result["resulting_state"] == "REFUSED"
+    assert result["receipt"]["failure_code"] == "CONTEXT_LINEAGE_REFUSED"
+
+
+def test_duplicate_key_is_rejected_after_context_verification():
+    gate, authority, _, context, _ = _gate()
+    _, envelope = _request(authority, context)
+    result = gate.evaluate(
+        raw_candidate=b'{"operation":"READ","operation":"DELETE"}',
+        raw_envelope=envelope,
+        current_time="2029-01-01T00:00:00Z",
+    )
+    assert result["resulting_state"] == "REFUSED"
+    assert (
+        result["receipt"]["failure_code"]
+        == "INVALID_INPUT:CanonicalJSONError"
+    )
 
 
 def test_signing_or_append_failure_fails_closed():
-    gate, authority, _ = _gate()
-    candidate, envelope = _request(authority)
+    gate, authority, _, context, _ = _gate()
+    candidate, envelope = _request(authority, context)
+
     class BrokenLedger:
-        def append_decision(self, *_): raise OSError("offline")
-        def get_receipt(self, *_): return None
+        def append_decision(self, *_):
+            raise OSError("offline")
+
+        def get_receipt(self, *_):
+            return None
+
     gate.ledger = BrokenLedger()
-    result = gate.evaluate(raw_candidate=candidate, raw_envelope=envelope, current_time="2029-01-01T00:00:00Z")
-    assert result == {"resulting_state": "CUTOFF", "failure_code": "RECEIPT_PRESERVATION_UNAVAILABLE", "durable_receipt": False}
+    result = gate.evaluate(
+        raw_candidate=candidate,
+        raw_envelope=envelope,
+        current_time="2029-01-01T00:00:00Z",
+    )
+    assert result == {
+        "resulting_state": "CUTOFF",
+        "failure_code": "RECEIPT_PRESERVATION_UNAVAILABLE",
+        "durable_receipt": False,
+    }
 
 
 def test_lineage_verifier_rejects_tampered_receipt_content():
-    gate, authority, ledger = _gate()
-    candidate, envelope = _request(authority)
-    result = gate.evaluate(raw_candidate=candidate, raw_envelope=envelope, current_time="2029-01-01T00:00:00Z")
-    ledger._records[result["receipt_hash"]]["requested_operation"] = "DELETE"
-    assert not AuthenticatedLineageVerifier(ledger, Secp256k1Verifier()).verify(result["receipt_hash"])
+    gate, authority, ledger, context, _ = _gate()
+    candidate, envelope = _request(authority, context)
+    result = gate.evaluate(
+        raw_candidate=candidate,
+        raw_envelope=envelope,
+        current_time="2029-01-01T00:00:00Z",
+    )
+    ledger._records[result["receipt_hash"]][
+        "requested_operation"
+    ] = "DELETE"
+    assert not AuthenticatedLineageVerifier(
+        ledger, Secp256k1Verifier()
+    ).verify(result["receipt_hash"])

--- a/tests/test_context_snapshot.py
+++ b/tests/test_context_snapshot.py
@@ -1,0 +1,100 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from context_snapshot import (
+    ContextSnapshot,
+    ContextValidationError,
+    InMemoryContextResolver,
+    InMemoryDefinitionResolver,
+    canonical_json,
+    definition_id_for_mapping,
+    make_definition_record,
+    resolve_verified_context,
+)
+
+
+def _fixtures():
+    definition = make_definition_record(
+        namespace_id="tas:core",
+        term="authorized",
+        semantic_version="1",
+        definition="Authenticated external authority with valid scope.",
+    )
+    definition_id = definition_id_for_mapping(definition)
+    snapshot = ContextSnapshot.build(
+        namespace_id="tas:core",
+        context_sequence=0,
+        definition_ids=[definition_id],
+        invariant_set_id="b" * 64,
+        authority_binding_hash="a" * 64,
+        parent_context_hash=None,
+        effective_epoch=7,
+    )
+    return definition, definition_id, snapshot
+
+
+def test_context_snapshot_round_trip_pins_ordered_definitions():
+    definition, definition_id, snapshot = _fixtures()
+    context_resolver = InMemoryContextResolver(
+        {snapshot.context_snapshot_hash: canonical_json(snapshot.mapping)},
+        {snapshot.namespace_id: snapshot.context_snapshot_hash},
+    )
+    definition_resolver = InMemoryDefinitionResolver(
+        {definition_id: canonical_json(definition)}
+    )
+    resolved = resolve_verified_context(
+        context_snapshot_hash=snapshot.context_snapshot_hash,
+        context_resolver=context_resolver,
+        definition_resolver=definition_resolver,
+    )
+    assert resolved == snapshot
+
+
+def test_context_hash_is_not_self_referential_and_detects_mutation():
+    _, _, snapshot = _fixtures()
+    mutated = snapshot.mapping
+    mutated["effective_epoch"] = 8
+    with pytest.raises(
+        ContextValidationError, match="context_snapshot_hash mismatch"
+    ):
+        ContextSnapshot.from_raw(canonical_json(mutated))
+
+
+def test_definition_content_cannot_be_swapped_behind_same_id():
+    definition, definition_id, snapshot = _fixtures()
+    swapped = dict(definition)
+    swapped["definition"] = "A silently substituted meaning."
+    context_resolver = InMemoryContextResolver(
+        {snapshot.context_snapshot_hash: canonical_json(snapshot.mapping)},
+        {snapshot.namespace_id: snapshot.context_snapshot_hash},
+    )
+    definition_resolver = InMemoryDefinitionResolver(
+        {definition_id: canonical_json(swapped)}
+    )
+    with pytest.raises(ContextValidationError, match="DefinitionID"):
+        resolve_verified_context(
+            context_snapshot_hash=snapshot.context_snapshot_hash,
+            context_resolver=context_resolver,
+            definition_resolver=definition_resolver,
+        )
+
+
+def test_stale_context_is_not_executable_after_namespace_head_advances():
+    definition, definition_id, snapshot = _fixtures()
+    context_resolver = InMemoryContextResolver(
+        {snapshot.context_snapshot_hash: canonical_json(snapshot.mapping)},
+        {snapshot.namespace_id: "f" * 64},
+    )
+    definition_resolver = InMemoryDefinitionResolver(
+        {definition_id: canonical_json(definition)}
+    )
+    with pytest.raises(ContextValidationError, match="active namespace head"):
+        resolve_verified_context(
+            context_snapshot_hash=snapshot.context_snapshot_hash,
+            context_resolver=context_resolver,
+            definition_resolver=definition_resolver,
+        )


### PR DESCRIPTION
## Summary

- add `tas.context-snapshot.v1` as a strict content-addressed semantic context contract
- add domain-separated DefinitionIDs and an ordered registry-root commitment
- bind `AuthoritySnapshot` to the exact `context_snapshot_hash` without introducing a circular hash dependency
- resolve and verify context, namespace head, and pinned definitions before interpreting candidate payloads
- require context continuity across receipt lineage and fail closed on semantic teleportation
- include context, registry, invariant, declared candidate, and raw candidate-byte bindings in signed receipts
- add JSON Schemas for context snapshots and definition records

## Why

PR #38 authenticated authority and candidate lineage but left semantic definitions external to the signed transition. A mutable dictionary could therefore change the meaning of an already-authorized operation without forging a signature. This change makes the interpretive environment part of authenticated state.

## Compatibility

- authorization envelopes advance to `schema_version: 2`
- `AdmissionGatekeeper` now requires `context_resolver` and `definition_resolver`
- legacy `AuthoritySnapshot` construction remains source-compatible, but snapshots without `context_snapshot_hash` fail closed

## Validation

- `python -m py_compile context_snapshot.py admission_gate.py`
- `pytest -q`
- 12 focused tests passed locally, covering canonical hashing, definition substitution, stale namespace heads, context-first evaluation, authority/context mismatch, context-lineage discontinuity, signature refusal, durable receipts, and tamper detection
