### PR TITLE
Specify CRP receipt and migration contracts, OpenAPI, docs, and tests

### DIFF
--- a/docs/crp-receipt-contracts.md
+++ b/docs/crp-receipt-contracts.md
@@ -1,0 +1,91 @@
+# Canonical Readiness Protocol Receipt Contracts
+
+## Status and order of operations
+
+This document makes the payload shape normative for `tas.crp.receipt.v1` and
+`tas.crp.migration.v1`. It intentionally precedes verifier implementation. The
+schemas constrain representation; the semantic rules below constrain meaning.
+
+Signature input is the UTF-8 encoding of the payload after JSON Canonicalization
+Scheme (RFC 8785) serialization. A proof is detached because a signature cannot
+be a member of the value that it signs. The OpenAPI component `DetachedProof`
+defines the transport form. Implementations MUST reject duplicate JSON member
+names, values not admitted by I-JSON/RFC 8785, unknown members, unresolved schema
+references, and non-canonical payload bytes.
+
+## Completion receipts
+
+The normative schema is [`tas.crp.receipt.v1.schema.json`](../schemas/tas.crp.receipt.v1.schema.json).
+A completion receipt commits to exactly one gate evaluation, its complete
+evidence set, the evaluated scope, verifier implementation, authority snapshot,
+and predecessor. Gate 1 has no predecessor. Gates 2 through 4 MUST identify the
+digest of the immediately preceding, valid PASS receipt under the same
+`protocol_id`, `protocol_version`, and `scope_digest`.
+
+Receipt evaluation MUST apply this fail-closed order:
+
+1. Require exact schema, protocol identity, and supported semantic version.
+2. Recompute `sha256:` plus the lowercase SHA-256 hex digest of the canonical
+   payload and compare it with `DetachedProof.payload_digest`, then verify the
+   Ed25519 signature using the proof's `key_id`.
+3. Establish historical validity at `evaluated_at`: the key MUST have been
+   authorized for the evaluator and gate, `evaluated_at` MUST be on or after
+   `key_valid_from` and before `key_valid_until` when an end exists, and the
+   signed authority snapshot MUST agree with the authoritative snapshot digest.
+4. Establish current effectiveness independently. Revocation does not rewrite a
+   historically valid receipt, but policy MAY make that receipt ineffective for
+   a new decision. An evaluator MUST report historical validity and current
+   effectiveness separately.
+5. Resolve the unique predecessor chain without gaps or forks to the current
+   head for the exact protocol version and scope.
+6. Derive state: a current FAIL head is `BLOCKED`; no Gate 1 head is
+   `NOT_EVALUATED`; a PASS head at Gates 1–3 is `IN_PROGRESS`; only a PASS Gate 4
+   head is `IOC_READY`.
+
+`status_checked_at` records when the authority registry was consulted. It MUST
+not be earlier than `evaluated_at`. A receipt producer MUST use a unique
+`receipt_id`, include at least one evidence digest, and reject ambiguous evidence
+names. These cross-field and registry rules are verifier obligations rather than
+claims that JSON Schema alone can prove.
+
+## Migration receipts and version isolation
+
+The normative schema is [`tas.crp.migration.v1.schema.json`](../schemas/tas.crp.migration.v1.schema.json).
+`source_version` and `target_version` MUST differ. A migration result is PASS if
+and only if every required target-version invariant is present exactly once and
+has a PASS attestation. The verifier MUST resolve `source_head_digest` to the
+unique effective source head and MUST recompute `target_scope_digest` under the
+target version's semantics.
+
+A valid PASS migration receipt establishes the imported head from which target
+version evaluation may proceed. A missing, invalid, untrusted, ambiguous, or
+FAIL migration establishes no target head; the target version therefore derives
+`NOT_EVALUATED`. Source receipts remain historical records and never become
+target-version receipts by inheritance.
+
+## Time-separated authority decisions
+
+The embedded authority object is evidence about the evaluation-time
+authorization snapshot, not a timeless declaration that a key is trusted.
+Verification therefore returns two decisions:
+
+- **Historical validity:** whether identity, signature, authorization at
+  `evaluated_at`, schema semantics, and ancestry were valid for the receipt.
+- **Current effectiveness:** whether current policy permits the historically
+  valid chain to authorize the decision being made now.
+
+Implementations MUST NOT erase historical validity after key rotation or later
+revocation. They MUST NOT infer current effectiveness merely from a historically
+valid signature. Compromise policy can deny current effectiveness immediately
+while preserving the immutable audit fact.
+
+## Protocol boundary
+
+Schema revisions (`schema_id`) and CRP semantic versions (`protocol_version`) are
+independent. A compatible representation correction may introduce a future
+schema without changing protocol semantics. Any changed gate meaning, evidence
+requirement, authority rule, ancestry rule, or state derivation requires a new
+semantic `protocol_version` and the migration boundary above.
+
+The schemas and semantic rules are the contract. A later verifier must implement
+them; its runtime behavior cannot silently extend them.

--- a/docs/ioc-runway.md
+++ b/docs/ioc-runway.md
@@ -12,6 +12,10 @@ As of **2026-07-29**, the IOC target is **23 calendar days away**.
 - **Completion receipt:** The durable, cryptographically bound output proving that a readiness gate was evaluated against identified evidence and recording its result.
 - **Readiness state:** A result derived from valid completion receipts. It is never a manually asserted label.
 
+The normative completion and migration payload contracts, signature boundary,
+version-isolation rules, and time-separated authority decisions are specified in
+[`crp-receipt-contracts.md`](crp-receipt-contracts.md).
+
 The IOC runway is an execution instance of the Canonical Readiness Protocol. The protocol defines the required sequence, evidence, verification procedures, authorities, and receipts by which readiness is established. No task, phase, or deployment state is complete merely because it is marked complete; completion exists only when the protocol admits the required evidence and produces a valid completion receipt.
 
 ## Runway Summary

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openai>=1.0.0
 pytest>=7.0.0
+jsonschema[format]>=4.23.0
 cryptography>=42.0.0

--- a/schemas/tas.crp.migration.v1.schema.json
+++ b/schemas/tas.crp.migration.v1.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://truealphaspiral.org/schemas/tas.crp.migration.v1.schema.json",
+  "title": "TAS Canonical Readiness Protocol Migration Payload v1",
+  "description": "A signed transition between isolated CRP semantic versions.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_id", "canonicalization", "protocol_id", "migration_id",
+    "source_version", "target_version", "source_head_digest", "target_scope_digest",
+    "result", "evaluated_at", "invariant_attestations", "verifier", "authority"
+  ],
+  "properties": {
+    "schema_id": {"const": "tas.crp.migration.v1"},
+    "canonicalization": {"const": "RFC8785"},
+    "protocol_id": {"const": "tas.crp"},
+    "migration_id": {"$ref": "tas.crp.receipt.v1.schema.json#/$defs/urnUuid"},
+    "source_version": {"$ref": "tas.crp.receipt.v1.schema.json#/$defs/semver"},
+    "target_version": {"$ref": "tas.crp.receipt.v1.schema.json#/$defs/semver"},
+    "source_head_digest": {"$ref": "tas.crp.receipt.v1.schema.json#/$defs/digest"},
+    "target_scope_digest": {"$ref": "tas.crp.receipt.v1.schema.json#/$defs/digest"},
+    "result": {"enum": ["PASS", "FAIL"]},
+    "evaluated_at": {"$ref": "tas.crp.receipt.v1.schema.json#/$defs/timestamp"},
+    "invariant_attestations": {
+      "type": "array", "minItems": 1,
+      "items": {
+        "type": "object", "additionalProperties": false,
+        "required": ["invariant_id", "evidence_digest", "result"],
+        "properties": {
+          "invariant_id": {"type": "string", "minLength": 1, "maxLength": 256},
+          "evidence_digest": {"$ref": "tas.crp.receipt.v1.schema.json#/$defs/digest"},
+          "result": {"enum": ["PASS", "FAIL"]}
+        }
+      }
+    },
+    "verifier": {"$ref": "tas.crp.receipt.v1.schema.json#/$defs/verifier"},
+    "authority": {"$ref": "tas.crp.receipt.v1.schema.json#/$defs/authority"}
+  }
+}

--- a/schemas/tas.crp.receipt.v1.schema.json
+++ b/schemas/tas.crp.receipt.v1.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://truealphaspiral.org/schemas/tas.crp.receipt.v1.schema.json",
+  "title": "TAS Canonical Readiness Protocol Receipt Payload v1",
+  "description": "The payload covered by a detached signature. The signature itself is deliberately not part of this object.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_id", "canonicalization", "protocol_id", "protocol_version",
+    "receipt_id", "gate", "result", "evaluated_at", "scope_digest",
+    "parent_receipt_digest", "evidence", "verifier", "authority"
+  ],
+  "properties": {
+    "schema_id": {"const": "tas.crp.receipt.v1"},
+    "canonicalization": {"const": "RFC8785"},
+    "protocol_id": {"const": "tas.crp"},
+    "protocol_version": {"$ref": "#/$defs/semver"},
+    "receipt_id": {"$ref": "#/$defs/urnUuid"},
+    "gate": {"type": "integer", "minimum": 1, "maximum": 4},
+    "result": {"enum": ["PASS", "FAIL"]},
+    "evaluated_at": {"$ref": "#/$defs/timestamp"},
+    "scope_digest": {"$ref": "#/$defs/digest"},
+    "parent_receipt_digest": {
+      "oneOf": [{"type": "null"}, {"$ref": "#/$defs/digest"}]
+    },
+    "evidence": {
+      "type": "array", "minItems": 1, "items": {"$ref": "#/$defs/evidence"}
+    },
+    "verifier": {"$ref": "#/$defs/verifier"},
+    "authority": {"$ref": "#/$defs/authority"}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"gate": {"const": 1}}, "required": ["gate"]},
+      "then": {"properties": {"parent_receipt_digest": {"type": "null"}}},
+      "else": {"properties": {"parent_receipt_digest": {"$ref": "#/$defs/digest"}}}
+    }
+  ],
+  "$defs": {
+    "semver": {"type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"},
+    "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "urnUuid": {"type": "string", "pattern": "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"},
+    "timestamp": {"type": "string", "format": "date-time"},
+    "evidence": {
+      "type": "object", "additionalProperties": false,
+      "required": ["name", "digest"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1, "maxLength": 128},
+        "digest": {"$ref": "#/$defs/digest"},
+        "media_type": {"type": "string", "minLength": 1, "maxLength": 128},
+        "uri": {"type": "string", "format": "uri"}
+      }
+    },
+    "verifier": {
+      "type": "object", "additionalProperties": false,
+      "required": ["id", "version", "implementation_digest"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1, "maxLength": 128},
+        "version": {"$ref": "#/$defs/semver"},
+        "implementation_digest": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "authority": {
+      "type": "object", "additionalProperties": false,
+      "required": ["evaluator_id", "key_id", "authorization_snapshot_digest", "key_valid_from", "key_valid_until", "key_status_at_evaluation", "status_checked_at"],
+      "properties": {
+        "evaluator_id": {"type": "string", "minLength": 1, "maxLength": 256},
+        "key_id": {"type": "string", "minLength": 1, "maxLength": 256},
+        "authorization_snapshot_digest": {"$ref": "#/$defs/digest"},
+        "key_valid_from": {"$ref": "#/$defs/timestamp"},
+        "key_valid_until": {"oneOf": [{"type": "null"}, {"$ref": "#/$defs/timestamp"}]},
+        "key_status_at_evaluation": {"const": "ACTIVE"},
+        "status_checked_at": {"$ref": "#/$defs/timestamp"}
+      }
+    }
+  }
+}

--- a/schemas/tas.crp.v1.openapi.yaml
+++ b/schemas/tas.crp.v1.openapi.yaml
@@ -1,0 +1,30 @@
+openapi: 3.1.0
+info:
+  title: TAS Canonical Readiness Protocol Payloads
+  version: 1.0.0
+  description: Normative payload contracts. Signatures are detached and cover the RFC 8785 serialization of the payload.
+paths: {}
+components:
+  schemas:
+    CompletionReceiptPayload:
+      $ref: ./tas.crp.receipt.v1.schema.json
+    MigrationReceiptPayload:
+      $ref: ./tas.crp.migration.v1.schema.json
+    DetachedProof:
+      type: object
+      additionalProperties: false
+      required: [algorithm, key_id, payload_digest, signature]
+      properties:
+        algorithm:
+          const: Ed25519
+        key_id:
+          type: string
+          minLength: 1
+          maxLength: 256
+        payload_digest:
+          type: string
+          pattern: '^sha256:[0-9a-f]{64}$'
+        signature:
+          type: string
+          description: Unpadded base64url Ed25519 signature over the RFC 8785 payload bytes.
+          pattern: '^[A-Za-z0-9_-]{86}$'

--- a/tests/test_crp_schemas.py
+++ b/tests/test_crp_schemas.py
@@ -1,0 +1,127 @@
+import json
+from copy import deepcopy
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+from referencing import Registry, Resource
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMAS = ROOT / "schemas"
+SHA = "sha256:" + "a" * 64
+OTHER_SHA = "sha256:" + "b" * 64
+
+
+def load(name):
+    return json.loads((SCHEMAS / name).read_text(encoding="utf-8"))
+
+
+def validator(name):
+    schema = load(name)
+    receipt_schema = load("tas.crp.receipt.v1.schema.json")
+    registry = Registry().with_resource(
+        receipt_schema["$id"], Resource.from_contents(receipt_schema)
+    )
+    return Draft202012Validator(
+        schema,
+        registry=registry,
+        format_checker=FormatChecker(),
+    )
+
+
+def authority():
+    return {
+        "evaluator_id": "tas:evaluator:release-board",
+        "key_id": "tas:key:2026-07",
+        "authorization_snapshot_digest": OTHER_SHA,
+        "key_valid_from": "2026-07-01T00:00:00Z",
+        "key_valid_until": None,
+        "key_status_at_evaluation": "ACTIVE",
+        "status_checked_at": "2026-08-01T12:00:00Z",
+    }
+
+
+def verifier_value():
+    return {
+        "id": "tas-crp-verifier",
+        "version": "1.0.0",
+        "implementation_digest": OTHER_SHA,
+    }
+
+
+def receipt(gate=1):
+    return {
+        "schema_id": "tas.crp.receipt.v1",
+        "canonicalization": "RFC8785",
+        "protocol_id": "tas.crp",
+        "protocol_version": "1.0.0",
+        "receipt_id": "urn:uuid:123e4567-e89b-42d3-a456-426614174000",
+        "gate": gate,
+        "result": "PASS",
+        "evaluated_at": "2026-08-01T12:00:00Z",
+        "scope_digest": SHA,
+        "parent_receipt_digest": None if gate == 1 else OTHER_SHA,
+        "evidence": [{"name": "gate-evidence", "digest": OTHER_SHA}],
+        "verifier": verifier_value(),
+        "authority": authority(),
+    }
+
+
+def migration():
+    return {
+        "schema_id": "tas.crp.migration.v1",
+        "canonicalization": "RFC8785",
+        "protocol_id": "tas.crp",
+        "migration_id": "urn:uuid:123e4567-e89b-42d3-a456-426614174001",
+        "source_version": "1.0.0",
+        "target_version": "2.0.0",
+        "source_head_digest": SHA,
+        "target_scope_digest": OTHER_SHA,
+        "result": "PASS",
+        "evaluated_at": "2026-08-01T12:00:00Z",
+        "invariant_attestations": [
+            {"invariant_id": "tas.crp.v2:chain", "evidence_digest": SHA, "result": "PASS"}
+        ],
+        "verifier": verifier_value(),
+        "authority": authority(),
+    }
+
+
+def test_completion_receipt_accepts_each_valid_gate_shape():
+    check = validator("tas.crp.receipt.v1.schema.json")
+    for gate in range(1, 5):
+        check.validate(receipt(gate))
+
+
+def test_completion_receipt_enforces_ancestry_and_closed_shape():
+    check = validator("tas.crp.receipt.v1.schema.json")
+    bad_parent = receipt(2)
+    bad_parent["parent_receipt_digest"] = None
+    assert list(check.iter_errors(bad_parent))
+
+    unknown = receipt()
+    unknown["readiness_state"] = "IOC_READY"
+    assert list(check.iter_errors(unknown))
+
+
+def test_completion_receipt_rejects_wrong_protocol_or_digest():
+    check = validator("tas.crp.receipt.v1.schema.json")
+    for field, value in (("protocol_id", "other"), ("scope_digest", "a" * 64)):
+        candidate = receipt()
+        candidate[field] = value
+        assert list(check.iter_errors(candidate))
+
+
+def test_migration_payload_resolves_shared_definitions():
+    validator("tas.crp.migration.v1.schema.json").validate(migration())
+
+
+def test_migration_payload_requires_attestations_and_rejects_extra_state():
+    check = validator("tas.crp.migration.v1.schema.json")
+    no_attestations = migration()
+    no_attestations["invariant_attestations"] = []
+    assert list(check.iter_errors(no_attestations))
+
+    asserted_head = deepcopy(migration())
+    asserted_head["current_head"] = SHA
+    assert list(check.iter_errors(asserted_head))


### PR DESCRIPTION
### Motivation

- Formalize the Canonical Readiness Protocol (CRP) payload contracts so gate evaluations and cross-version migrations are unambiguous, canonicalizable, and cryptographically provable. 
- Prevent silent version/semantics drift by enforcing a fail-closed verification order, time-separated authority decisions, and an explicit migration boundary between protocol versions.

### Description

- Add strict Draft 2020-12 JSON Schemas for `tas.crp.receipt.v1` and `tas.crp.migration.v1` that require RFC 8785 canonicalization, protocol identity, ordered gates (1–4), evidence digests, verifier metadata, and evaluation-time authority snapshots (`schemas/tas.crp.receipt.v1.schema.json`, `schemas/tas.crp.migration.v1.schema.json`).
- Publish an OpenAPI 3.1 component bundle referencing the schemas and a `DetachedProof` form for Ed25519 proofs over RFC 8785 bytes (`schemas/tas.crp.v1.openapi.yaml`).
- Add normative specification and verification semantics in `docs/crp-receipt-contracts.md` and link the contracts into the IOC runway documentation (`docs/ioc-runway.md`).
- Add schema validation tests (`tests/test_crp_schemas.py`) that exercise valid/invalid completion receipts and migration payload shapes and wire the tests to a local schema registry via `referencing.Registry`, and add `jsonschema[format]>=4.23.0` to `requirements.txt`.

### Testing

- Ran `pytest -q` which executed the new tests alongside the suite and reported all tests passing (`409 passed`).
- Verified both JSON schema files parse with `python -m json.tool schemas/tas.crp.receipt.v1.schema.json` and `python -m json.tool schemas/tas.crp.migration.v1.schema.json` without errors.
- Exercised the new `tests/test_crp_schemas.py` which validates gate shapes, ancestry rules, protocol/digest errors, migration attestations, and extra-field rejection and all assertions passed under the test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e3ba359b883339a63d440918eaba3)