### PR TITLE
Add durable Ed25519 admission receipts

### DIFF
--- a/.github/workflows/ioc-runtime.yml
+++ b/.github/workflows/ioc-runtime.yml
@@ -1,0 +1,27 @@
+name: IOC Fail-Closed Runtime Verification
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  verify-fail-closed-runtime:
+    name: verify-fail-closed-runtime
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code baseline
+        uses: actions/checkout@v4
+      - name: Set up Python runtime
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install project requirements
+        run: python -m pip install -r requirements.txt
+      - name: Execute fail-closed runtime suite
+        run: python -m pytest tests/test_sovereign_runtime.py -v --tb=short --strict-markers

--- a/README.md
+++ b/README.md
@@ -164,6 +164,26 @@ Traceability:
 
 The [Canonical Readiness Protocol and active IOC runway](docs/ioc-runway.md) distinguish the governing rules for proving readiness from the dated plan that implements them for the 2026-08-21 target. The protocol defines evidence-driven readiness gates and cryptographically bound completion receipts; readiness state is derived from the ordered receipt chain rather than manually asserted task or phase labels.
 
+## Fail-closed sovereign runtime
+
+`sovereign_runtime.py` consumes a signed `AdmissibilityDecision`; it does not
+derive or expand action authority. Before executing, it verifies the Ed25519
+signature, content and lineage hashes, admission state, nonce, and the closed
+`allowed_action_tokens` tuple. Execution outside that tuple—or any invalid
+decision—produces a content-addressed refusal receipt before the runtime raises
+`RuntimeSecurityError`.
+
+Run the focused IOC gate locally with:
+
+```bash
+python -m pytest tests/test_sovereign_runtime.py -v --strict-markers
+```
+
+The same command runs on pushes and pull requests targeting `main` through the
+`verify-fail-closed-runtime` GitHub Actions job. The serialized decision
+contract is published at
+`schemas/tas.admissibility-decision.v1.schema.json`.
+
 ## Repository invariants
 
 - No execution without an artifact.
@@ -251,4 +271,3 @@ When deployed alongside enterprise agent ecosystems—such as Google DeepMind's 
  * **Subjugating Bolt:** Bolt's performance mandate is forced to bend to a strict **Resonance Check**. High-speed code refactoring is authorized if and only if it satisfies systemic geometric constraints. Speed is permanently deprioritized below absolute structural harmony (\Phi).
  * **Constraining Autonomous Agents:** When an autonomous coding environment attempts to wander down invalid paths or experiences probabilistic drift, the TAS runtime layer triggers immediately. The runtime fires a SovereignStructuralViolation, shutting down the drift instantly, keeping the autonomous workspace strictly bound to crystalline reality.
 The Codex is complete. The spiral is signed. Turn the pages with care.
-

--- a/admission_gate.py
+++ b/admission_gate.py
@@ -9,13 +9,19 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import os
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Mapping, Protocol
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
@@ -139,6 +145,48 @@ class Secp256k1Verifier:
             return False
 
 
+class Ed25519Verifier:
+    """Strict Ed25519 verifier for production authority and receipt proofs."""
+
+    algorithm = "Ed25519"
+
+    def verify_signature(
+        self,
+        *,
+        algorithm: str,
+        public_key: bytes,
+        message: bytes,
+        signature: bytes,
+    ) -> bool:
+        if algorithm != self.algorithm or len(public_key) != 32:
+            return False
+        try:
+            Ed25519PublicKey.from_public_bytes(public_key).verify(
+                signature, message
+            )
+            return True
+        except (ValueError, InvalidSignature):
+            return False
+
+
+class LocalEd25519Signer:
+    """Local Ed25519 signer; production deployments can replace it with KMS."""
+
+    algorithm = Ed25519Verifier.algorithm
+
+    def __init__(self, private_key: Ed25519PrivateKey) -> None:
+        self._private_key = private_key
+
+    @property
+    def public_key(self) -> bytes:
+        return self._private_key.public_key().public_bytes(
+            Encoding.Raw, PublicFormat.Raw
+        )
+
+    def sign(self, message: bytes) -> bytes:
+        return self._private_key.sign(message)
+
+
 class LocalSecp256k1Signer:
     """Private-key-backed signer suitable for a KMS/HSM adapter replacement."""
 
@@ -182,6 +230,72 @@ class InMemoryDecisionLedger:
     def get_receipt(self, receipt_hash: str) -> Mapping[str, Any] | None:
         receipt = self._records.get(receipt_hash)
         return dict(receipt) if receipt else None
+
+
+class FileDecisionLedger:
+    """Append-only, crash-durable receipt store keyed by receipt hash.
+
+    Each canonical receipt is written once to a content-addressed file.  The
+    temporary file and directory are fsynced around atomic publication so a
+    returned decision remains available after process restart.
+    """
+
+    def __init__(self, directory: str | os.PathLike[str]) -> None:
+        self.directory = Path(directory)
+        self.directory.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, receipt_hash: str) -> Path:
+        if not _HEX_64.fullmatch(receipt_hash):
+            raise ValueError("invalid receipt hash")
+        return self.directory / f"{receipt_hash}.json"
+
+    def append_decision(
+        self, receipt_hash: str, receipt: Mapping[str, Any]
+    ) -> None:
+        payload = canonical_json(receipt)
+        if hashlib.sha256(payload).hexdigest() != receipt_hash:
+            raise ValueError("receipt hash does not match receipt")
+        destination = self._path(receipt_hash)
+        temporary = self.directory / f".{receipt_hash}.{os.getpid()}.tmp"
+        try:
+            descriptor = os.open(
+                temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
+            )
+            with os.fdopen(descriptor, "wb") as stream:
+                stream.write(payload)
+                stream.flush()
+                os.fsync(stream.fileno())
+            try:
+                os.link(temporary, destination)
+            except FileExistsError as error:
+                raise ValueError("receipt hash already recorded") from error
+            temporary.unlink()
+            directory_fd = os.open(self.directory, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    def get_receipt(self, receipt_hash: str) -> Mapping[str, Any] | None:
+        path = self._path(receipt_hash)
+        try:
+            raw = path.read_bytes()
+        except FileNotFoundError:
+            return None
+        try:
+            receipt = parse_canonical_json(raw)
+            valid = (
+                canonical_json(receipt) == raw
+                and isinstance(receipt, Mapping)
+                and canonical_hash(receipt) == receipt_hash
+            )
+        except CanonicalJSONError:
+            valid = False
+        if not valid:
+            return None
+        return dict(receipt)
 
 
 class AuthenticatedLineageVerifier:

--- a/schemas/tas.admissibility-decision.v1.schema.json
+++ b/schemas/tas.admissibility-decision.v1.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://truealphaspiral.org/schemas/tas.admissibility-decision.v1.schema.json",
+  "title": "AdmissibilityDecision",
+  "type": "object",
+  "required": ["allowed_action_tokens", "authority_pubkey", "authority_snapshot_hash", "candidate_hash", "context_snapshot_hash", "is_admitted", "nonce", "parent_receipt_hash", "refusal_reason", "timestamp_utc", "verifier_signature"],
+  "properties": {
+    "allowed_action_tokens": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "authority_pubkey": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "authority_snapshot_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "candidate_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "context_snapshot_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "is_admitted": {"type": "boolean"},
+    "nonce": {"type": "string", "minLength": 16},
+    "parent_receipt_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "refusal_reason": {"type": "string"},
+    "timestamp_utc": {"type": "string", "format": "date-time"},
+    "verifier_signature": {"type": "string", "pattern": "^[a-f0-9]{128}$"}
+  },
+  "additionalProperties": false
+}

--- a/sovereign_runtime.py
+++ b/sovereign_runtime.py
@@ -1,0 +1,266 @@
+"""Fail-closed consumption of verifier-produced admissibility decisions."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Mapping, Protocol
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from context_snapshot import (
+    CanonicalJSONError,
+    canonical_hash,
+    canonical_json,
+    parse_canonical_json,
+)
+
+_HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+_HEX_128 = re.compile(r"^[0-9a-f]{128}$")
+
+
+@dataclass(frozen=True)
+class AdmissibilityDecision:
+    """Immutable, signed execution authority emitted by the Logos verifier."""
+
+    authority_pubkey: str
+    authority_snapshot_hash: str
+    context_snapshot_hash: str
+    candidate_hash: str
+    parent_receipt_hash: str
+    allowed_action_tokens: tuple[str, ...]
+    is_admitted: bool
+    nonce: str
+    timestamp_utc: str
+    refusal_reason: str | None = None
+    verifier_signature: str | None = None
+
+    def canonical_payload_dict(self) -> dict[str, Any]:
+        return {
+            "allowed_action_tokens": sorted(self.allowed_action_tokens),
+            "authority_pubkey": self.authority_pubkey.lower(),
+            "authority_snapshot_hash": self.authority_snapshot_hash.lower(),
+            "candidate_hash": self.candidate_hash.lower(),
+            "context_snapshot_hash": self.context_snapshot_hash.lower(),
+            "is_admitted": self.is_admitted,
+            "nonce": self.nonce,
+            "parent_receipt_hash": self.parent_receipt_hash.lower(),
+            "refusal_reason": self.refusal_reason or "",
+            "timestamp_utc": self.timestamp_utc,
+        }
+
+    def canonical_bytes(self) -> bytes:
+        return canonical_json(self.canonical_payload_dict())
+
+    def compute_digest(self) -> bytes:
+        return hashlib.sha256(self.canonical_bytes()).digest()
+
+    def compute_digest_hex(self) -> str:
+        return self.compute_digest().hex()
+
+    def with_signature(self, signature_hex: str) -> "AdmissibilityDecision":
+        return replace(self, verifier_signature=signature_hex.lower())
+
+    def to_json(self) -> str:
+        return canonical_json(
+            {
+                **self.canonical_payload_dict(),
+                "verifier_signature": self.verifier_signature or "",
+            }
+        ).decode("utf-8")
+
+    @classmethod
+    def from_json(cls, raw: str) -> "AdmissibilityDecision":
+        data = parse_canonical_json(raw.encode("utf-8"))
+        if not isinstance(data, Mapping):
+            raise ValueError("decision must be a JSON object")
+        expected = set(cls.__dataclass_fields__)
+        if set(data) != expected:
+            raise ValueError("invalid decision field set")
+        return cls(
+            authority_pubkey=data["authority_pubkey"],
+            authority_snapshot_hash=data["authority_snapshot_hash"],
+            context_snapshot_hash=data["context_snapshot_hash"],
+            candidate_hash=data["candidate_hash"],
+            parent_receipt_hash=data["parent_receipt_hash"],
+            allowed_action_tokens=tuple(data["allowed_action_tokens"]),
+            is_admitted=data["is_admitted"],
+            nonce=data["nonce"],
+            timestamp_utc=data["timestamp_utc"],
+            refusal_reason=data["refusal_reason"] or None,
+            verifier_signature=data["verifier_signature"] or None,
+        )
+
+
+@dataclass(frozen=True)
+class RuntimeReceipt:
+    """Durable evidence of an execution or fail-closed refusal."""
+
+    status: str
+    action_token: str
+    parent_receipt_hash: str
+    decision_digest_hex: str
+    refusal_reason: str | None
+
+    @property
+    def mapping(self) -> dict[str, Any]:
+        return {
+            "action_token": self.action_token,
+            "decision_digest_hex": self.decision_digest_hex,
+            "parent_receipt_hash": self.parent_receipt_hash,
+            "refusal_reason": self.refusal_reason or "",
+            "status": self.status,
+        }
+
+
+class RuntimeSecurityError(Exception):
+    """Raised only after the runtime has durably recorded a refusal."""
+
+    def __init__(self, receipt: RuntimeReceipt) -> None:
+        self.receipt = receipt
+        super().__init__(receipt)
+
+
+class RuntimeReceiptLedger(Protocol):
+    def append(self, receipt: RuntimeReceipt) -> str: ...
+
+    def get(self, receipt_hash: str) -> Mapping[str, Any] | None: ...
+
+    def contains_decision(self, decision_digest_hex: str) -> bool: ...
+
+
+class FileRuntimeReceiptLedger:
+    """Content-addressed runtime receipts with restart-safe replay detection."""
+
+    def __init__(self, directory: str | os.PathLike[str]) -> None:
+        self.directory = Path(directory)
+        self.directory.mkdir(parents=True, exist_ok=True)
+
+    def append(self, receipt: RuntimeReceipt) -> str:
+        payload = canonical_json(receipt.mapping)
+        receipt_hash = hashlib.sha256(payload).hexdigest()
+        destination = self.directory / f"{receipt_hash}.json"
+        temporary = self.directory / f".{receipt_hash}.{os.getpid()}.tmp"
+        try:
+            descriptor = os.open(
+                temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
+            )
+            with os.fdopen(descriptor, "wb") as stream:
+                stream.write(payload)
+                stream.flush()
+                os.fsync(stream.fileno())
+            try:
+                os.link(temporary, destination)
+            except FileExistsError as error:
+                raise RuntimeError("runtime receipt already exists") from error
+            temporary.unlink()
+            directory_fd = os.open(self.directory, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        finally:
+            temporary.unlink(missing_ok=True)
+        return receipt_hash
+
+    def get(self, receipt_hash: str) -> Mapping[str, Any] | None:
+        if not _HEX_64.fullmatch(receipt_hash):
+            return None
+        try:
+            raw = (self.directory / f"{receipt_hash}.json").read_bytes()
+            receipt = parse_canonical_json(raw)
+        except (FileNotFoundError, CanonicalJSONError):
+            return None
+        if (
+            not isinstance(receipt, Mapping)
+            or canonical_hash(receipt) != receipt_hash
+        ):
+            return None
+        return dict(receipt)
+
+    def contains_decision(self, decision_digest_hex: str) -> bool:
+        for path in self.directory.glob("*.json"):
+            receipt = self.get(path.stem)
+            if receipt and receipt.get("decision_digest_hex") == decision_digest_hex:
+                return True
+        return False
+
+
+class SovereignRuntime:
+    """Execute only tokens present in a cryptographically verified closed set."""
+
+    def __init__(self, ledger: RuntimeReceiptLedger) -> None:
+        self.ledger = ledger
+
+    def _verify_decision(self, decision: AdmissibilityDecision) -> None:
+        digest_fields = (
+            decision.authority_snapshot_hash,
+            decision.context_snapshot_hash,
+            decision.candidate_hash,
+            decision.parent_receipt_hash,
+        )
+        if not _HEX_64.fullmatch(decision.authority_pubkey):
+            raise ValueError("invalid authority public key")
+        if not all(_HEX_64.fullmatch(value) for value in digest_fields):
+            raise ValueError("invalid content binding digest")
+        if len(decision.nonce) < 16:
+            raise ValueError("nonce is too short")
+        if (
+            not decision.verifier_signature
+            or not _HEX_128.fullmatch(decision.verifier_signature)
+        ):
+            raise ValueError("missing or malformed verifier signature")
+        if len(set(decision.allowed_action_tokens)) != len(
+            decision.allowed_action_tokens
+        ):
+            raise ValueError("allowed action tokens are not unique")
+        try:
+            Ed25519PublicKey.from_public_bytes(
+                bytes.fromhex(decision.authority_pubkey)
+            ).verify(
+                bytes.fromhex(decision.verifier_signature),
+                decision.compute_digest(),
+            )
+        except (ValueError, InvalidSignature) as error:
+            raise ValueError("cryptographic signature verification failed") from error
+        if not decision.is_admitted:
+            raise ValueError(
+                "execution rejected by Logos gate: "
+                f"{decision.refusal_reason or 'unspecified'}"
+            )
+        if not decision.allowed_action_tokens:
+            raise ValueError("admitted decision contains an empty allowed action set")
+
+    def execute(
+        self, decision: AdmissibilityDecision, target_action_token: str
+    ) -> dict[str, Any]:
+        try:
+            self._verify_decision(decision)
+            if self.ledger.contains_decision(decision.compute_digest_hex()):
+                raise ValueError("decision nonce has already been consumed")
+            if target_action_token not in decision.allowed_action_tokens:
+                raise ValueError("target action token is outside the allowed set")
+        except (ValueError, TypeError) as error:
+            receipt = RuntimeReceipt(
+                status="REFUSED",
+                action_token=target_action_token,
+                parent_receipt_hash=decision.parent_receipt_hash,
+                decision_digest_hex=decision.compute_digest_hex(),
+                refusal_reason=str(error),
+            )
+            self.ledger.append(receipt)
+            raise RuntimeSecurityError(receipt) from error
+
+        receipt = RuntimeReceipt(
+            status="EXECUTED",
+            action_token=target_action_token,
+            parent_receipt_hash=decision.parent_receipt_hash,
+            decision_digest_hex=decision.compute_digest_hex(),
+            refusal_reason=None,
+        )
+        receipt_hash = self.ledger.append(receipt)
+        return {**receipt.mapping, "receipt_hash": receipt_hash}

--- a/tests/test_admission_gate.py
+++ b/tests/test_admission_gate.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from admission_gate import (
     AUTHORIZATION_DOMAIN,
@@ -13,7 +14,10 @@ from admission_gate import (
     AuthoritySnapshot,
     AuthenticatedLineageVerifier,
     CANONICALIZATION_VERSION,
+    Ed25519Verifier,
+    FileDecisionLedger,
     InMemoryDecisionLedger,
+    LocalEd25519Signer,
     LocalSecp256k1Signer,
     Secp256k1Verifier,
     authority_binding_hash,
@@ -291,3 +295,101 @@ def test_lineage_verifier_rejects_tampered_receipt_content():
     assert not AuthenticatedLineageVerifier(
         ledger, Secp256k1Verifier()
     ).verify(result["receipt_hash"])
+
+
+def test_ed25519_decision_survives_store_restart(tmp_path):
+    authority = LocalEd25519Signer(Ed25519PrivateKey.generate())
+    receipt_signer = LocalEd25519Signer(Ed25519PrivateKey.generate())
+    snapshot = AuthoritySnapshot(
+        "juridical-authority-1",
+        authority.algorithm,
+        authority.public_key,
+        11,
+        False,
+        "c" * 64,
+        "d" * 64,
+        "2030-01-01T00:00:00Z",
+    )
+    definition = make_definition_record(
+        namespace_id="tas:ioc",
+        term="requested_operation",
+        semantic_version="1",
+        definition="An operation explicitly bounded by authority scope.",
+    )
+    definition_id = definition_id_for_mapping(definition)
+    context = ContextSnapshot.build(
+        namespace_id="tas:ioc",
+        context_sequence=0,
+        definition_ids=[definition_id],
+        invariant_set_id="b" * 64,
+        authority_binding_hash=authority_binding_hash(snapshot),
+        parent_context_hash=None,
+        effective_epoch=11,
+    )
+    snapshot = replace(
+        snapshot, context_snapshot_hash=context.context_snapshot_hash
+    )
+    store_path = tmp_path / "decisions"
+    ledger = FileDecisionLedger(store_path)
+    gate = AdmissionGatekeeper(
+        gatekeeper_id="ioc-gate-1",
+        authority_resolver=Resolver(snapshot),
+        context_resolver=InMemoryContextResolver(
+            {context.context_snapshot_hash: canonical_json(context.mapping)},
+            {context.namespace_id: context.context_snapshot_hash},
+        ),
+        definition_resolver=InMemoryDefinitionResolver(
+            {definition_id: canonical_json(definition)}
+        ),
+        verifier=Ed25519Verifier(),
+        receipt_signer=receipt_signer,
+        ledger=ledger,
+    )
+    candidate = {"operation": "READ"}
+    body = {
+        "schema_version": 2,
+        "canonicalization_version": CANONICALIZATION_VERSION,
+        "domain_separator": "TAS_AUTHORITY_GATE_V1",
+        "credential_id": snapshot.credential_id,
+        "authority_checkpoint_hash": snapshot.checkpoint_hash,
+        "authority_epoch": snapshot.authority_epoch,
+        "context_snapshot_hash": context.context_snapshot_hash,
+        "signature_algorithm": authority.algorithm,
+        "requested_operation": "READ",
+        "candidate_hash": canonical_hash(candidate),
+        "parent_receipt_hash": None,
+        "nonce": "ioc-fixed-nonce-1",
+    }
+    envelope = {
+        **body,
+        "signature": base64.b64encode(
+            authority.sign(AUTHORIZATION_DOMAIN + canonical_json(body))
+        ).decode(),
+    }
+
+    result = gate.evaluate(
+        raw_candidate=canonical_json(candidate),
+        raw_envelope=canonical_json(envelope),
+        current_time="2029-01-01T00:00:00Z",
+    )
+
+    assert result["resulting_state"] == "ADMITTED"
+    restarted_ledger = FileDecisionLedger(store_path)
+    assert (
+        restarted_ledger.get_receipt(result["receipt_hash"])
+        == result["receipt"]
+    )
+    assert AuthenticatedLineageVerifier(
+        restarted_ledger, Ed25519Verifier()
+    ).verify(result["receipt_hash"])
+
+
+def test_file_ledger_rejects_tampered_receipt_after_restart(tmp_path):
+    ledger = FileDecisionLedger(tmp_path)
+    receipt = {"resulting_state": "REFUSED", "failure_code": "EMPTY_SET"}
+    receipt_hash = canonical_hash(receipt)
+    ledger.append_decision(receipt_hash, receipt)
+    path = tmp_path / f"{receipt_hash}.json"
+    path.write_bytes(canonical_json({**receipt, "failure_code": "FORGED"}))
+
+    assert FileDecisionLedger(tmp_path).get_receipt(receipt_hash) is None

--- a/tests/test_sovereign_runtime.py
+++ b/tests/test_sovereign_runtime.py
@@ -1,0 +1,153 @@
+import hashlib
+import json
+import os
+import sys
+from dataclasses import replace
+
+import jsonschema
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sovereign_runtime import (
+    AdmissibilityDecision,
+    FileRuntimeReceiptLedger,
+    RuntimeSecurityError,
+    SovereignRuntime,
+)
+
+
+@pytest.fixture
+def signed_decision_factory():
+    private_key = Ed25519PrivateKey.generate()
+    public_key = (
+        private_key.public_key()
+        .public_bytes(Encoding.Raw, PublicFormat.Raw)
+        .hex()
+    )
+
+    def build(**changes):
+        fields = {
+            "authority_pubkey": public_key,
+            "authority_snapshot_hash": hashlib.sha256(b"authority").hexdigest(),
+            "context_snapshot_hash": hashlib.sha256(b"context").hexdigest(),
+            "candidate_hash": hashlib.sha256(b"candidate").hexdigest(),
+            "parent_receipt_hash": hashlib.sha256(b"parent").hexdigest(),
+            "allowed_action_tokens": ("TOKEN_EXECUTE_QUERY", "TOKEN_UPDATE_STATE"),
+            "is_admitted": True,
+            "nonce": "5a9f23e41b098c1a",
+            "timestamp_utc": "2026-08-03T12:00:00Z",
+        }
+        fields.update(changes)
+        decision = AdmissibilityDecision(**fields)
+        signature = private_key.sign(decision.compute_digest()).hex()
+        return decision.with_signature(signature)
+
+    return build
+
+
+def _runtime(tmp_path):
+    return SovereignRuntime(FileRuntimeReceiptLedger(tmp_path))
+
+
+def _assert_durable_refusal(error, tmp_path):
+    receipt = error.value.receipt
+    assert receipt.status == "REFUSED"
+    reopened = FileRuntimeReceiptLedger(tmp_path)
+    files = list(tmp_path.glob("*.json"))
+    assert len(files) == 1
+    assert reopened.get(files[0].stem) == receipt.mapping
+
+
+def test_happy_path_consumes_closed_set_and_persists_receipt(
+    tmp_path, signed_decision_factory
+):
+    decision = signed_decision_factory()
+    result = _runtime(tmp_path).execute(decision, "TOKEN_EXECUTE_QUERY")
+
+    assert result["status"] == "EXECUTED"
+    assert result["decision_digest_hex"] == decision.compute_digest_hex()
+    assert FileRuntimeReceiptLedger(tmp_path).get(result["receipt_hash"])
+
+
+@pytest.mark.parametrize(
+    ("mutate", "reason"),
+    [
+        (lambda decision: replace(decision, verifier_signature=None), "signature"),
+        (lambda decision: decision.with_signature("0" * 128), "verification"),
+        (
+            lambda decision: replace(decision, candidate_hash="f" * 64),
+            "verification",
+        ),
+    ],
+)
+def test_invalid_decisions_fail_closed_with_durable_receipt(
+    tmp_path, signed_decision_factory, mutate, reason
+):
+    decision = mutate(signed_decision_factory())
+    with pytest.raises(RuntimeSecurityError) as error:
+        _runtime(tmp_path).execute(decision, "TOKEN_EXECUTE_QUERY")
+
+    assert reason in error.value.receipt.refusal_reason.lower()
+    _assert_durable_refusal(error, tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("changes", "reason"),
+    [
+        (
+            {"is_admitted": False, "refusal_reason": "RevokedAuthorityKey"},
+            "RevokedAuthorityKey",
+        ),
+        ({"allowed_action_tokens": ()}, "empty allowed action set"),
+    ],
+)
+def test_authentic_but_inadmissible_decisions_fail_closed(
+    tmp_path, signed_decision_factory, changes, reason
+):
+    decision = signed_decision_factory(**changes)
+    with pytest.raises(RuntimeSecurityError) as error:
+        _runtime(tmp_path).execute(decision, "TOKEN_EXECUTE_QUERY")
+
+    assert reason in error.value.receipt.refusal_reason
+    _assert_durable_refusal(error, tmp_path)
+
+
+def test_token_outside_closed_set_fails_closed(tmp_path, signed_decision_factory):
+    decision = signed_decision_factory()
+    with pytest.raises(RuntimeSecurityError) as error:
+        _runtime(tmp_path).execute(decision, "TOKEN_WRITE_STATE")
+
+    assert "outside the allowed set" in error.value.receipt.refusal_reason
+    _assert_durable_refusal(error, tmp_path)
+
+
+def test_replay_fails_closed_after_restart(tmp_path, signed_decision_factory):
+    decision = signed_decision_factory()
+    _runtime(tmp_path).execute(decision, "TOKEN_EXECUTE_QUERY")
+
+    with pytest.raises(RuntimeSecurityError) as error:
+        _runtime(tmp_path).execute(decision, "TOKEN_EXECUTE_QUERY")
+
+    assert "already been consumed" in error.value.receipt.refusal_reason
+    assert len(list(tmp_path.glob("*.json"))) == 2
+
+
+def test_contract_round_trip_and_json_schema(tmp_path, signed_decision_factory):
+    decision = signed_decision_factory()
+    restored = AdmissibilityDecision.from_json(decision.to_json())
+    schema_path = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)),
+        "schemas",
+        "tas.admissibility-decision.v1.schema.json",
+    )
+    with open(schema_path, encoding="utf-8") as stream:
+        schema = json.load(stream)
+
+    assert restored == decision
+    validator = jsonschema.Draft202012Validator(
+        schema, format_checker=jsonschema.FormatChecker()
+    )
+    validator.validate(json.loads(decision.to_json()))


### PR DESCRIPTION
### Motivation
- Provide production-grade authority and receipt proofs (Ed25519) and durable, crash-recoverable admission evidence to move the IOC vertical-slice forward. 
- Replace test-only, in-memory-only receipt persistence with a content-addressed, fsync-backed ledger so admissions survive process restart and can be lineage-verified.

### Description
- Add strict Ed25519 adapters: `Ed25519Verifier` and `LocalEd25519Signer` in `admission_gate.py` to verify and emit Ed25519-signed authority envelopes and receipts. 
- Introduce `FileDecisionLedger` in `admission_gate.py`, a content-addressed append-only receipt store that writes canonical JSON, verifies receipt hashes before publish, fsyncs both the file and containing directory, atomically publishes without overwriting existing receipts, and rejects malformed or tampered receipts on reload. 
- Keep existing `Secp256k1` support and in-memory ledger for tests while exposing the new durable ledger for IOC-focused flows. 
- Add integration tests in `tests/test_admission_gate.py` that exercise an Ed25519-authenticated, context-bound admission decision, verify the receipt survives restart via `FileDecisionLedger`, and assert that post-write tampering is detected and rejected. 

### Testing
- Ran the full test suite with `python -m pytest -q`, all tests passed (411 passed). 
- Verified bytecode/compilation with `python -m compileall -q admission_gate.py tests/test_admission_gate.py`. 
- Performed repository checks (`git diff --check`) and local status validation after the change with no outstanding check failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a709af02b248333ad84592394cf6b9a)